### PR TITLE
BCDA-2225 Docker image streamlining for DB migration

### DIFF
--- a/Dockerfiles/Dockerfile.migrate
+++ b/Dockerfiles/Dockerfile.migrate
@@ -1,0 +1,7 @@
+FROM migrate/migrate
+
+WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
+COPY . .
+
+WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
+ENTRYPOINT []

--- a/Dockerfiles/Dockerfile.migrate
+++ b/Dockerfiles/Dockerfile.migrate
@@ -1,7 +1,0 @@
-FROM migrate/migrate
-
-WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
-COPY . .
-
-WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
-ENTRYPOINT []

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -13,7 +13,7 @@ COPY . .
 RUN dep ensure
 
 RUN apt-get update
-RUN apt-get install apt-transport-https ca-certificates libunwind8 icu-devtools python-pip -y
+RUN apt-get install apt-transport-https ca-certificates -y
 
 RUN curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | apt-key add -
 RUN echo "deb https://packagecloud.io/golang-migrate/migrate/debian/ stretch main" > /etc/apt/sources.list.d/migrate.list

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -6,6 +6,7 @@ RUN go get -u github.com/xo/usql
 RUN go get -u github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u github.com/tsenart/vegeta
+RUN go get -tags 'postgres' -u github.com/golang-migrate/migrate/cmd/migrate
 
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
 COPY . .
@@ -13,12 +14,6 @@ COPY . .
 RUN dep ensure
 
 RUN apt-get update
-RUN apt-get install apt-transport-https ca-certificates -y
-
-RUN curl -L https://packagecloud.io/golang-migrate/migrate/gpgkey | apt-key add -
-RUN echo "deb https://packagecloud.io/golang-migrate/migrate/debian/ stretch main" > /etc/apt/sources.list.d/migrate.list
-RUN apt-get update
-RUN apt-get install migrate -y
 
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
 ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	$(MAKE) migrations-test
 
 load-fixtures:
-	docker-compose -f docker-compose.test.yml run --rm -w /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations tests migrate -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path ./ up
+	docker-compose -f docker-compose.test.yml run --rm migrate /migrate -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path db/migrations/ up
 	docker-compose -f docker-compose.yml run ssas sh -c 'tmp/ssas-service --add-fixture-data'
 
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ test:
 	$(MAKE) migrations-test
 
 load-fixtures:
-	docker pull migrate/migrate
-	docker run --rm --network=bcda-ssas-app_default -v ${PWD}:/go/src/github.com/CMSgov/bcda-ssas-app migrate/migrate -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations up
+	docker-compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations up
 	docker-compose -f docker-compose.yml run ssas sh -c 'tmp/ssas-service --add-fixture-data'
 
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ test:
 	$(MAKE) migrations-test
 
 load-fixtures:
-	docker-compose -f docker-compose.test.yml run --rm migrate /migrate -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path db/migrations/ up
+	docker pull migrate/migrate
+	docker run --rm --network=bcda-ssas-app_default -v ${PWD}:/go/src/github.com/CMSgov/bcda-ssas-app migrate/migrate -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations up
 	docker-compose -f docker-compose.yml run ssas sh -c 'tmp/ssas-service --add-fixture-data'
 
 docker-build:

--- a/docker-compose.migrate.yml
+++ b/docker-compose.migrate.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  migrate:
+    image: migrate/migrate
+    volumes:
+      - .:/go/src/github.com/CMSgov/bcda-ssas-app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -51,9 +51,3 @@ services:
       dockerfile: Dockerfiles/Dockerfile.postman_test
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-ssas-app
-  migrate:
-    build:
-      context: .
-      dockerfile: Dockerfiles/Dockerfile.migrate
-    volumes:
-      - .:/go/src/github.com/CMSgov/bcda-ssas-app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -51,3 +51,9 @@ services:
       dockerfile: Dockerfiles/Dockerfile.postman_test
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-ssas-app
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfiles/Dockerfile.migrate
+    volumes:
+      - .:/go/src/github.com/CMSgov/bcda-ssas-app


### PR DESCRIPTION
### Fixes [BCDA-2225](https://jira.cms.gov/browse/BCDA-2225)
Everything _functions_ in our DB migration strategy, but there is room for some refinements.  This PR uses a new dedicated Docker container for DB schema migrations, and streamlines the method for installing the migration utility in the `tests` container.

### Proposed Changes
- When possible, use the Docker image provided by the team that writes our database migration utility
- Install the `golang/migrations` utility in the `tests` container by using `go get` rather than via `apt-get`.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
The new methods of getting the migration utility are at least as trustworthy as what we are currently using.

### Acceptance Validation
<img width="916" alt="Screen Shot 2019-11-04 at 5 33 23 PM" src="https://user-images.githubusercontent.com/2533561/68163751-39cd2b00-ff29-11e9-953d-403fa8a98e0d.png">

### Feedback Requested
Are there any further steps we should take?
