### PR TITLE
BCDA-2243: Enhance the SSAS `/_version` endpoint 

### DIFF
--- a/ops/build_and_package.sh
+++ b/ops/build_and_package.sh
@@ -26,7 +26,7 @@ fi
 cd ../ssas
 go clean
 echo "Building ssas..."
-go build -o ssas ./service/main
+go build -ldflags "-X github.com/CMSgov/bcda-ssas-app/ssas/constants.Version=$VERSION" -o ssas ./service/main
 echo "Packaging ssas binary into RPM..."
 fpm -v $VERSION -s dir -t rpm -n ssas ssas=/usr/local/bin/ssas
 

--- a/ssas/constants/constants.go
+++ b/ssas/constants/constants.go
@@ -1,4 +1,4 @@
 package constants
 
-// This is set during compilation.  See build_and_package.sh in the ops repo
+// This is set during compilation.  See build_and_package.sh in the /ops directory
 var Version = "latest"

--- a/ssas/constants/constants.go
+++ b/ssas/constants/constants.go
@@ -1,0 +1,4 @@
+package constants
+
+// This is set during compilation.  See build_and_package.sh in the ops repo
+var Version = "latest"

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/go-chi/chi"
 
+	"github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 )
 
-var version = "latest"
 var infoMap map[string][]string
 var adminSigningKeyPath string
 var server *service.Server
@@ -23,7 +23,7 @@ func init() {
 // Server creates an SSAS admin server
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
-	server = service.NewServer("admin", ":3004", version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute)
+	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -8,10 +8,10 @@ import (
 	"github.com/go-chi/chi"
 
 	"github.com/CMSgov/bcda-ssas-app/ssas"
+        "github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 )
 
-var version = "latest"
 var infoMap map[string][]string
 var publicSigningKeyPath string
 var server *service.Server
@@ -24,7 +24,7 @@ func init() {
 
 func Server() (*service.Server) {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
-	server = service.NewServer("public", ":3003", version, infoMap, routes(), unsafeMode, publicSigningKeyPath, 20 * time.Minute)
+	server = service.NewServer("public", ":3003", constants.Version, infoMap, routes(), unsafeMode, publicSigningKeyPath, 20 * time.Minute)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "public", ":3003")}

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -126,7 +126,7 @@ func (s *Server) getInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getVersion(w http.ResponseWriter, r *http.Request) {
 	respMap := make(map[string]string)
 	respMap["version"] = fmt.Sprintf("%v", s.version)
-	render.JSON(w, r, s.version)
+	render.JSON(w, r, respMap)
 }
 
 func (s *Server) getHealthCheck(w http.ResponseWriter, r *http.Request) {

--- a/ssas/service/server_test.go
+++ b/ssas/service/server_test.go
@@ -75,7 +75,7 @@ func (s *ServerTestSuite) TestGetVersion() {
 
 	assert.Equal(s.T(), http.StatusOK, rr.Result().StatusCode)
 	b, _ := ioutil.ReadAll(rr.Result().Body)
-	assert.Contains(s.T(), string(b), "9.99.999")
+	assert.Contains(s.T(), string(b), `{"version":"9.99.999"}`)
 }
 
 func (s *ServerTestSuite) TestGetHealthCheck() {


### PR DESCRIPTION

### Fixes [BCDA-2243](https://jira.cms.gov/browse/BCDA-2243)

The SSAS service `/_version` endpoint currently produces a version string that is hardcoded and not in JSON format.


### Change Details

- Added a `constants` file (similar to BCDA) which contains a `Version` string (defaults to `latest`)
- Updated the `build_and_package` script to define the application's version at build time.  For reference, when this is called from Jenkins to build a release, the version that is passed in corresponds to the branch or tag.
- Updated the existing `/_version` endpoints to return `constants.Version` in JSON format (and updated corresponding unit tests).


### Security Implications

This change does not have any security implications.  The endpoint that is updated as part of this change returns software version information.  No PHI/PII is involved.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Testing performed locally only, since we are currently unable to deploy to `dev` from this repository.  Additional validation will be performed as part of [BCDA-2018](https://jira.cms.gov/browse/BCDA-2018).

<img width="351" alt="Screen Shot 2019-11-04 at 9 57 28 PM" src="https://user-images.githubusercontent.com/37818548/68175107-27191d00-ff4e-11e9-81b9-2c12c4c874ce.png">
<img width="343" alt="Screen Shot 2019-11-04 at 9 57 37 PM" src="https://user-images.githubusercontent.com/37818548/68175108-27b1b380-ff4e-11e9-86e8-6fefd00937ef.png">


### Feedback Requested

Please review.
