### PR TITLE
BCDA-2018: Build/Package SSAS from new repo

### DIFF
--- a/Dockerfiles/Dockerfile.package
+++ b/Dockerfiles/Dockerfile.package
@@ -7,6 +7,8 @@ ARG GPG_RPM_EMAIL
 ARG BCDA_GPG_RPM_PASSPHRASE
 
 RUN apt-get update
+RUN apt-get install -y build-essential ruby ruby-dev rpm git
+RUN gem install --no-ri --no-rdoc fpm etc
 RUN go get -u github.com/golang/dep/cmd/dep
 
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app

--- a/ops/Jenkinsfile.build_trigger
+++ b/ops/Jenkinsfile.build_trigger
@@ -50,12 +50,8 @@ pipeline {
     stage('Build and Package') {
      steps {
         build job: 'BCDA - Build and Package',
-        /*
-          This will be enabled as part of BCDA-2018.  Until then, a parameter for SSAS_GIT_VERSION does not exist.
+        // Since this is being triggered by a code delivery to SSAS repo, it should always be built with BCDA master
         parameters: [string(string(name: 'SSAS_GIT_VERSION', value: "${env.BRANCH_NAME}"), name: 'BCDA_GIT_VERSION', value: "master"),  string(name: 'DEPLOY', value: "${DEPLOY}")],
-        */
-        // Since this is being triggered by a delivery to SSAS repo, it should always be built with BCDA master
-        parameters: [string(name: 'BCDA_GIT_VERSION', value: "master"), string(name: 'DEPLOY', value: "${DEPLOY}")],
         wait: true,
         propagate: true
      }


### PR DESCRIPTION
### Fixes [BCDA-2018](https://jira.cms.gov/browse/BCDA-2018)

Build and package of SSAS artifacts should originate from `bcda-ssas-app` and `bcda-ssas-ops`, and be removed from `bcda-app`.

### Change Details

In addition to this PR, three other PRs are involved in this work:
-  https://github.com/CMSgov/bcda-app/pull/420
-  https://github.com/CMSgov/bcda-ops/pull/313
-  https://github.com/CMSgov/bcda-ssas-ops/pull/1

Unique work specific to this PR includes:
-  Updated the Docker image used to create the RPM to include the correct utilities (when this code was moved from `bcda-app` to `bcda-ssas-app`, the utilities must have been accidentally removed from the Dockerfile).  
- Updated the build trigger (fired when code is pushed to `master`) to pass along the `SSAS_GIT_VERSION` (which will be `master` about 99.9% of the time) 

### Security Implications

The SSAS application code has been moved from `bcda-app` to `bcda-ssas-app`, and deployment scripts have been updated to use the artifacts built from the new repository.  No new dependencies have been introduced, and secure data is not affected.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change and can be viewed [here](https://confluence.cms.gov/display/BCDA/Sprint+6.1+-+Security+Checklist)
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

Build/package/deploy/test is passing in Jenkins (all of the following jobs cascaded from the initial build):
- API/Worker Build/Package: [Jenkins job #1113](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1113/)
- SSAS Build/Package: [Jenkins job #7](https://bcda-ci.adhocteam.us/job/SSAS%20-%20Build%20and%20Package/7/)
- Deployment to `dev`: [Jenkins job #1006](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Deploy/1006/)
- Smoke test: [Jenkins job #1175](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/1175/)

Screenshots of the `/_version` for BCDA in `dev` and SSAS in `dev` show that the correct artifacts were deployed:

<img width="381" alt="Screen Shot 2019-11-12 at 3 53 23 PM" src="https://user-images.githubusercontent.com/37818548/68730492-daab8e00-059a-11ea-8d53-7b4ee7b883e5.png">
<img width="802" alt="Screen Shot 2019-11-12 at 3 53 37 PM" src="https://user-images.githubusercontent.com/37818548/68730495-de3f1500-059a-11ea-93b0-d7c1fe161f14.png">



### Feedback Requested

Please review.
