### PR TITLE
BCDA-2379 Feature: Add credential expiration when rotating credentials

### DIFF
--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -538,6 +538,7 @@ func (system *System) ResetSecret(trackingID string) (Credentials, error) {
 
 	OperationSucceeded(newSecretEvent)
 
+	creds.SystemID = fmt.Sprint(system.ID)
 	creds.ClientID = system.ClientID
 	creds.ClientSecret = secretString
 	creds.ClientName = system.ClientName

--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -1198,12 +1198,14 @@
 					"listen": "test",
 					"script": {
 						"id": "20ed753f-bd64-4270-9993-305d4efc1372",
-						"exec": [
+					  	"exec": [
 							"var schema = {",
 							"    \"properties\": {",
 							"        \"client_id\": { \"type\": \"string\" },",
-							"        \"secret\": { \"type\": \"string\" },",
-							"        \"expires_in\": { \"type\": \"string\", \"format\": \"time\" }",
+							"        \"client_secret\": { \"type\": \"string\" },",
+							"        \"client_name\": { \"type\": \"string\" },",
+							"        \"system_id\": { \"type\": \"string\" },",
+							"        \"expires_at\": { \"type\": \"string\", \"format\": \"time\" }",
 							"    }",
 							"};",
 							"var Ajv = require('ajv');",
@@ -1217,10 +1219,9 @@
 							"    pm.expect(ajv.validate(schema, pm.response.text())).to.be.true;",
 							"});",
 							"",
-							"// uncomment when client_id bug is fixed",
-							"//pm.test(\"client_id has expected value\", function () {",
-							"//    pm.response.to.have.jsonBody(\"client_id\", pm.environment.get(\"client_id\"))",
-							"//});",
+							"pm.test(\"client_id has expected value\", function () {",
+							"    pm.response.to.have.jsonBody(\"client_id\", pm.environment.get(\"client_id\"))",
+							"});",
 							"",
 							"var respJson = pm.response.json();",
 							"",
@@ -1228,11 +1229,10 @@
 							"    pm.expect(respJson.client_secret).to.not.eql(\"\");",
 							"});",
 							"",
-							"// uncomment when client_id bug is fixed ",
-							"//pm.environment.set(\"client_id\", respJson.client_id);  ",
+							"pm.environment.set(\"client_id\", respJson.client_id);  ",
 							"pm.environment.set(\"client_secret\", respJson.client_secret);",
 							""
-						],
+					  	],
 						"type": "text/javascript"
 					}
 				}


### PR DESCRIPTION
### Fixes [BCDA-2379](https://jira.cms.gov/browse/BCDA-2379)
When creating a system, we show when the new credentials expire.  When rotating credentials, we don't--yet!  This PR fixes that.

### Proposed Changes
- Make output of `PUT /system/[id]/credentials` identical to the output of `POST /system`
- Update Postman (smoke) test suite to look for new values

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
No new information is being provided; no new attack vector is presented.

### Acceptance Validation
#### Before
<img width="873" alt="Screen Shot 2019-11-14 at 2 09 19 PM" src="https://user-images.githubusercontent.com/2533561/68888487-09d01580-06e9-11ea-826d-fd1522435b88.png">

#### After
<img width="873" alt="Screen Shot 2019-11-14 at 2 11 47 PM" src="https://user-images.githubusercontent.com/2533561/68888488-09d01580-06e9-11ea-8117-eafa0ddc8b98.png">

### Feedback Requested
All feedback welcome!