### PR TITLE
BCDA-2378 Feature: Allow systems to register IP addresses

### DIFF
--- a/db/migrations/000004_ips.down.sql
+++ b/db/migrations/000004_ips.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE ips;

--- a/db/migrations/000004_ips.up.sql
+++ b/db/migrations/000004_ips.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE public.ips (
     created_at timestamp with time zone,
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
-    address CIDR NOT NULL,
+    address INET NOT NULL,
     system_id integer NOT NULL
 );
 ALTER TABLE public.ips OWNER TO postgres;

--- a/db/migrations/000004_ips.up.sql
+++ b/db/migrations/000004_ips.up.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+CREATE TABLE public.ips (
+    id integer NOT NULL,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone,
+    address CIDR NOT NULL,
+    system_id integer NOT NULL
+);
+ALTER TABLE public.ips OWNER TO postgres;
+CREATE SEQUENCE public.ips_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE public.ips_id_seq OWNER TO postgres;
+ALTER SEQUENCE public.ips_id_seq OWNED BY public.ips.id;
+ALTER TABLE ONLY public.ips ALTER COLUMN id SET DEFAULT nextval('public.ips_id_seq'::regclass);
+ALTER TABLE ONLY public.ips
+    ADD CONSTRAINT ips_pkey PRIMARY KEY (id);
+CREATE INDEX idx_ips_deleted_at ON public.ips USING btree (deleted_at);
+ALTER TABLE ONLY public.ips
+    ADD CONSTRAINT ips_system_id_systems_id_foreign FOREIGN KEY (system_id) REFERENCES public.systems(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+COMMIT;

--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -35,9 +35,11 @@ func TestAllMigrations(t *testing.T) {
 	require.True(t, t.Run("up1", up1))
 	require.True(t, t.Run("up2", up2))
 	require.True(t, t.Run("up3", up3))
+	require.True(t, t.Run("up4", up4))
 	// Place all "up" migrations in order above this comment
 
 	// Place all "down" migrations in reverse order below this comment
+	require.True(t, t.Run("down4", down4))
 	require.True(t, t.Run("down3", down3))
 	require.True(t, t.Run("down2", down2))
 	require.True(t, t.Run("down1", down1))
@@ -142,6 +144,24 @@ func up3(t *testing.T) {
 	}
 
 	assert.Nil(t, ssas.CleanDatabase(group))
+}
+
+func up4(t *testing.T) {
+	success := runMigration(t, "4")
+	assert.True(t, success)
+
+	if !db.HasTable("ips") {
+		t.Errorf("table ips was not created")
+	}
+}
+
+func down4(t *testing.T) {
+	success := runMigration(t, "3")
+	assert.True(t, success)
+
+	if db.HasTable("ips") {
+		t.Errorf("table ips is still present")
+	}
 }
 
 func down3(t *testing.T) {

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -19,11 +19,11 @@ type Group struct {
 }
 
 type SystemSummary struct {
-	ID			uint		`json:"id"`
+	ID        	uint    	`json:"id"`
 	ClientName	string		`json:"client_name"`
-	ClientID	string		`json:"client_id"`
-	IPs			[]string	`json:"ips,omitempty"`
-	UpdatedAt	time.Time	`json:"updated_at"`
+	ClientID	string  	`json:"client_id"`
+	IPs       	[]string	`json:"ips,omitempty"`
+	UpdatedAt 	time.Time	`json:"updated_at"`
 }
 
 type GroupSummary struct {

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -22,6 +22,7 @@ type SystemSummary struct {
 	ID         uint      `json:"id"`
 	ClientName string    `json:"client_name"`
 	ClientID   string    `json:"client_id"`
+	IPs		 []string	 `json:"ips,omitempty"`
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
@@ -108,6 +109,7 @@ func ListGroups(trackingID string) (list GroupList, err error) {
 			ss.ID = system.ID
 			ss.ClientName = system.ClientName
 			ss.ClientID = system.ClientID
+			ss.IPs, _ = system.GetIPs()
 			ss.UpdatedAt = system.UpdatedAt
 
 			gs.Systems = append(gs.Systems, ss)

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -19,11 +19,11 @@ type Group struct {
 }
 
 type SystemSummary struct {
-	ID         uint      `json:"id"`
-	ClientName string    `json:"client_name"`
-	ClientID   string    `json:"client_id"`
-	IPs		 []string	 `json:"ips,omitempty"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID			uint		`json:"id"`
+	ClientName	string		`json:"client_name"`
+	ClientID	string		`json:"client_id"`
+	IPs			[]string	`json:"ips,omitempty"`
+	UpdatedAt	time.Time	`json:"updated_at"`
 }
 
 type GroupSummary struct {

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -124,6 +124,7 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 		GroupID    string `json:"group_id"`
 		Scope      string `json:"scope"`
 		PublicKey  string `json:"public_key"`
+		IPs      []string `json:"ips"`
 		TrackingID string `json:"tracking_id"`
 	}
 
@@ -134,7 +135,7 @@ func createSystem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ssas.OperationCalled(ssas.Event{Op: "RegisterClient", TrackingID: sys.TrackingID, Help: "calling from admin.createSystem()"})
-	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.TrackingID)
+	creds, err := ssas.RegisterSystem(sys.ClientName, sys.GroupID, sys.Scope, sys.PublicKey, sys.IPs, sys.TrackingID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Could not create system. Error: %s", err), http.StatusBadRequest)
 		return
@@ -195,11 +196,7 @@ func getPublicKey(w http.ResponseWriter, r *http.Request) {
 
 	trackingID := uuid.NewRandom().String()
 	ssas.OperationCalled(ssas.Event{Op: "GetEncryptionKey", TrackingID: trackingID, Help: "calling from admin.getPublicKey()"})
-	key, err := system.GetEncryptionKey(trackingID)
-	if err != nil {
-		http.Error(w, "Internal error", http.StatusInternalServerError)
-		return
-	}
+	key, _ := system.GetEncryptionKey(trackingID)
 
 	w.Header().Set("Content-Type", "application/json")
 	keyStr := strings.Replace(key.Body, "\n", "\\n", -1)

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -243,6 +244,55 @@ func (s *APITestSuite) TestCreateSystem() {
 	assert.NotEmpty(s.T(), result["client_id"])
 	assert.NotEmpty(s.T(), result["client_secret"])
 	assert.Equal(s.T(), "Test Client", result["client_name"])
+
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestCreateSystemMultipleIps() {
+	group := ssas.Group{GroupID: "test-group-id"}
+	err := s.db.Save(&group).Error
+	if err != nil {
+		s.FailNow("Error creating test data", err.Error())
+	}
+
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"client_name": "Test Client", "group_id": "test-group-id", "scope": "bcda-api", "ips": ["192.0.2.0/24", "2001:db8::0/32"],"tracking_id": "T00000"}`))
+	handler := http.HandlerFunc(createSystem)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusCreated, rr.Result().StatusCode)
+	assert.Equal(s.T(), "application/json", rr.Result().Header.Get("Content-Type"))
+
+	creds := ssas.Credentials{}
+	err = json.NewDecoder(bytes.NewReader(rr.Body.Bytes())).Decode(&creds)
+	assert.Nil(s.T(), err)
+	assert.NotEmpty(s.T(), creds)
+	assert.NotEqual(s.T(), "", creds.ClientID)
+	assert.Equal(s.T(), "Test Client", creds.ClientName)
+
+	system, err := ssas.GetSystemByClientID(creds.ClientID)
+	assert.Nil(s.T(), err)
+	ips, err := system.GetIPs()
+	assert.Nil(s.T(), err)
+	assert.True(s.T(), contains(ips, "192.0.2.0/24"))
+	assert.True(s.T(), contains(ips, "2001:db8::/32")) // Note the translation of "2001:db8::0/32" to "2001:db8::/32"
+
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestCreateSystemBadIp() {
+	group := ssas.Group{GroupID: "test-group-id"}
+	err := s.db.Save(&group).Error
+	if err != nil {
+		s.FailNow("Error creating test data", err.Error())
+	}
+
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"client_name": "Test Client", "group_id": "test-group-id", "scope": "bcda-api", ips: ["304.0.2.1/32"],"tracking_id": "T00000"}`))
+	handler := http.HandlerFunc(createSystem)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
@@ -500,4 +550,13 @@ func (s *APITestSuite) TestDeactivateSystemCredentials() {
 
 func TestAPITestSuite(t *testing.T) {
 	suite.Run(t, new(APITestSuite))
+}
+
+func contains(list []string, target string) bool {
+	for _, item := range list {
+		if item == target {
+			return true
+		}
+	}
+	return false
 }

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -256,7 +256,7 @@ func (s *APITestSuite) TestCreateSystemMultipleIps() {
 		s.FailNow("Error creating test data", err.Error())
 	}
 
-	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"client_name": "Test Client", "group_id": "test-group-id", "scope": "bcda-api", "ips": ["192.0.2.0/24", "2001:db8::0/32"],"tracking_id": "T00000"}`))
+	req := httptest.NewRequest("POST", "/auth/system", strings.NewReader(`{"client_name": "Test Client", "group_id": "test-group-id", "scope": "bcda-api", "ips": ["8.8.8.8", "200:1:1:1::1"],"tracking_id": "T00000"}`))
 	handler := http.HandlerFunc(createSystem)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -274,8 +274,8 @@ func (s *APITestSuite) TestCreateSystemMultipleIps() {
 	assert.Nil(s.T(), err)
 	ips, err := system.GetIPs()
 	assert.Nil(s.T(), err)
-	assert.True(s.T(), contains(ips, "192.0.2.0/24"))
-	assert.True(s.T(), contains(ips, "2001:db8::/32")) // Note the translation of "2001:db8::0/32" to "2001:db8::/32"
+	assert.True(s.T(), contains(ips, "8.8.8.8"))
+	assert.True(s.T(), contains(ips, "200:1:1:1::1"))
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -118,7 +118,7 @@ func addFixtureData() {
 		fmt.Println(err)
 	}
 	// group for cms_id A9994; client_id 0c527d2e-2e8a-4808-b11d-0fa06baf8254
-	if err := db.Save(&ssas.Group{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254", Data: ssas.GroupData{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254"}, XData: `"{\"cms_ids\":[\"A9994\"]}"`}).Error; err != nil {
+	if err := db.Save(&ssas.Group{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254", Data: ssas.GroupData{GroupID: "0c527d2e-2e8a-4808-b11d-0fa06baf8254"}, XData: `{"cms_ids":["A9994"]}`}).Error; err != nil {
 		fmt.Println(err)
 	}
 	makeSystem(db, "admin", "31e029ef-0e97-47f8-873c-0e8b7e7f99bf",
@@ -199,7 +199,7 @@ func newAdminSystem(name string) {
 
 	trackingID := cliTrackingID()
 	ssas.OperationCalled(ssas.Event{Op: "RegisterSystem", TrackingID: trackingID, Help: "calling from main.newAdminSystem()"})
-	if c, err = ssas.RegisterSystem(name, "admin", "bcda-api", pk, trackingID); err != nil {
+	if c, err = ssas.RegisterSystem(name, "admin", "bcda-api", pk, []string{}, trackingID); err != nil {
 		ssas.Logger.Error(err)
 		return
 	}

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -36,6 +36,7 @@ type RegistrationRequest struct {
 	ClientName  string `json:"client_name"`
 	Scope       string `json:"scope,omitempty"`
 	JSONWebKeys JWKS   `json:"jwks"`
+	IPs		  []string `json:"ips"`
 }
 
 type ResetRequest struct {
@@ -386,7 +387,7 @@ func RegisterSystem(w http.ResponseWriter, r *http.Request) {
 	trackingID = uuid.NewRandom().String()
 	event := ssas.Event{Op: "RegisterClient", TrackingID: trackingID, Help: "calling from public.RegisterSystem()"}
 	ssas.OperationCalled(event)
-	credentials, err := ssas.RegisterSystem(reg.ClientName, rd.GroupID, reg.Scope, publicKeyPEM, trackingID)
+	credentials, err := ssas.RegisterSystem(reg.ClientName, rd.GroupID, reg.Scope, publicKeyPEM, reg.IPs, trackingID)
 	if err != nil {
 		jsonError(w, "invalid_client_metadata", err.Error())
 		return

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -224,7 +224,7 @@ func (s *APITestSuite) TestTokenSuccess() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Token Test", creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
@@ -257,7 +257,7 @@ func (s *APITestSuite) TestIntrospectSuccess() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Introspect Test", groupID, ssas.DefaultScope, pemString, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem("Introspect Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Introspect Test", creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -357,9 +357,8 @@ func RegisterSystem(clientName string, groupID string, scope string, publicKeyPE
 	}
 
 	for _, address := range ips {
-		_, _, err = net.ParseCIDR(address)
-		if err != nil {
-			regEvent.Help = fmt.Sprintf("invalid CIDR %s; %s", address, err.Error())
+		if !validAddress(address) {
+			regEvent.Help = fmt.Sprintf("invalid IP %s", address)
 			OperationFailed(regEvent)
 			tx.Rollback()
 			return creds, errors.New("error in ip address(es)")
@@ -372,7 +371,7 @@ func RegisterSystem(clientName string, groupID string, scope string, publicKeyPE
 
 		err = tx.Create(&ip).Error
 		if err != nil {
-			regEvent.Help = fmt.Sprintf("could not save CIDR %s; %s", address, err.Error())
+			regEvent.Help = fmt.Sprintf("could not save IP %s; %s", address, err.Error())
 			OperationFailed(regEvent)
 			tx.Rollback()
 			return creds, errors.New("error in ip address(es)")
@@ -647,4 +646,46 @@ func CleanDatabase(group Group) error {
 	}
 
 	return nil
+}
+
+func validAddress(address string) bool {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return false
+	}
+
+	// Source https://en.wikipedia.org/wiki/Reserved_IP_addresses
+	badNetworks := []string{
+		"0.0.0.0/8",
+		"10.0.0.0/8",
+		"100.64.0.0/10",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"172.16.0.0/12",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"192.88.99.0/24",
+		"192.168.0.0/16",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		"255.255.255.255/32",
+		"::/128",
+		"::1/128",
+		"2001:db8::/32",
+		"2002::/16",
+		"fc00::/7",
+		"fe80::/10",
+		"ff00::/8",
+	}
+	for _, network := range badNetworks {
+		_, ipNet, _ := net.ParseCIDR(network)
+		if ipNet.Contains(ip) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -286,12 +286,12 @@ func (system *System) GenerateSystemKeyPair() (string, error) {
 }
 
 type Credentials struct {
-	ClientID		string		`json:"client_id"`
-	ClientSecret	string		`json:"client_secret"`
-	SystemID		string		`json:"system_id"`
-	ClientName		string		`json:"client_name"`
-	IPs				[]string	`json:"ips,omitempty"`
-	ExpiresAt		time.Time	`json:"expires_at"`
+	ClientID    	string  	`json:"client_id"`
+	ClientSecret	string  	`json:"client_secret"`
+	SystemID    	string  	`json:"system_id"`
+	ClientName  	string  	`json:"client_name"`
+	IPs         	[]string	`json:"ips,omitempty"`
+	ExpiresAt   	time.Time	`json:"expires_at"`
 }
 
 /*

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -286,12 +286,12 @@ func (system *System) GenerateSystemKeyPair() (string, error) {
 }
 
 type Credentials struct {
-	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"`
-	SystemID     string    `json:"system_id"`
-	ClientName   string    `json:"client_name"`
-	IPs		   []string	   `json:"ips,omitempty"`
-	ExpiresAt    time.Time `json:"expires_at"`
+	ClientID		string		`json:"client_id"`
+	ClientSecret	string		`json:"client_secret"`
+	SystemID		string		`json:"system_id"`
+	ClientName		string		`json:"client_name"`
+	IPs				[]string	`json:"ips,omitempty"`
+	ExpiresAt		time.Time	`json:"expires_at"`
 }
 
 /*

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -485,7 +485,7 @@ func (s *SystemsTestSuite) TestRegisterSystemIps() {
 		assert.Equal([]string{address}, ips)
 	}
 
-	// We have no limit on the number of IP ranges that can be registered with a system
+	// We have no limit on the number of IP addresses that can be registered with a system
 	creds, err := RegisterSystem("Test system with all good IPs", groupID, DefaultScope, pubKey, goodIps, trackingID)
 	assert.Nil(err, "An array of good IP's should be a allowed, but was not")
 	assert.NotEmpty(creds)

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -404,7 +404,7 @@ func (s *SystemsTestSuite) TestRegisterSystemSuccess() {
 	pubKey, err := generatePublicKey(2048)
 	assert.Nil(err)
 
-	creds, err := RegisterSystem("Create System Test", groupID, DefaultScope, pubKey, trackingID)
+	creds, err := RegisterSystem("Create System Test", groupID, DefaultScope, pubKey, []string{}, trackingID)
 	assert.Nil(err)
 	assert.Equal("Create System Test", creds.ClientName)
 	assert.NotEqual("", creds.ClientSecret)
@@ -428,19 +428,79 @@ func (s *SystemsTestSuite) TestRegisterSystemMissingData() {
 	assert.Nil(err)
 
 	// No clientName
-	creds, err := RegisterSystem("", groupID, DefaultScope, pubKey, trackingID)
+	creds, err := RegisterSystem("", groupID, DefaultScope, pubKey, []string{}, trackingID)
 	assert.EqualError(err, "clientName is required")
 	assert.Empty(creds)
 
 	// No scope = success
-	creds, err = RegisterSystem("Register System Success2", groupID, "", pubKey, trackingID)
+	creds, err = RegisterSystem("Register System Success2", groupID, "", pubKey, []string{}, trackingID)
 	assert.Nil(err)
 	assert.NotEmpty(creds)
 
 	// No scope = success
-	creds, err = RegisterSystem("Register System Failure", groupID, "badScope", pubKey, trackingID)
+	creds, err = RegisterSystem("Register System Failure", groupID, "badScope", pubKey, []string{}, trackingID)
 	assert.NotNil(err)
 	assert.Empty(creds)
+
+	err = CleanDatabase(group)
+	assert.Nil(err)
+}
+
+func (s *SystemsTestSuite) TestRegisterSystemIps() {
+	assert := s.Assert()
+
+	goodIps := []string{
+		"192.168.0.1/32",			// Single IP's should have a 32-bit mask
+		"2001:db8:a0b:12f0::1/128",	// . . . 128-bit for IPv6
+		"192.168.0.0/24",			// Ranges are good
+		"2001:db8::/32",
+		"10.0.0.0/8",				// We don't care how BIG the range is
+	}
+
+	badIps := []string{
+		"asdf",
+		"192.168.0.1/24",			// Postgres CIDR type does not allow bits to the right of the mask
+		"2001:db8:a0b:12f0::1/32",	// . . . same for IPv6
+		"256.0.0.0/32",				// 255 is the max integer for IPv4
+		"10.0.0.1",					// Must be a CIDR, with mask
+	}
+
+	trackingID := uuid.NewRandom().String()
+	groupID := "T98987"
+	group := Group{GroupID: groupID}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	pubKey, err := generatePublicKey(2048)
+	assert.Nil(err)
+
+	for _, address := range goodIps {
+		creds, err := RegisterSystem("Test system with " + address, groupID, DefaultScope, pubKey, []string{address}, trackingID)
+		assert.Nil(err, fmt.Sprintf("%s should be a good CIDR, but was not allowed", address))
+		assert.NotEmpty(creds)
+		system, err := GetSystemByID(creds.SystemID)
+		assert.Nil(err)
+		ips, err := system.GetIPs()
+		assert.Nil(err)
+		assert.Equal([]string{address}, ips)
+	}
+
+	// We have no limit on the number of IP ranges that can be registered with a system
+	creds, err := RegisterSystem("Test system with all good IPs", groupID, DefaultScope, pubKey, goodIps, trackingID)
+	assert.Nil(err, "An array of good IP's should be a allowed, but was not")
+	assert.NotEmpty(creds)
+
+	for _, address := range badIps {
+		creds, err := RegisterSystem("Test system with " + address, groupID, DefaultScope, pubKey, []string{address}, trackingID)
+		if err == nil {
+			assert.Fail(fmt.Sprintf("%s should be a bad CIDR, but was allowed", address))
+		} else {
+			assert.EqualError(err, "error in ip address(es)")
+		}
+		assert.Empty(creds)
+	}
 
 	err = CleanDatabase(group)
 	assert.Nil(err)
@@ -461,17 +521,17 @@ func (s *SystemsTestSuite) TestRegisterSystemBadKey() {
 	assert.Nil(err)
 
 	// Blank key ok
-	creds, err := RegisterSystem("Register System Failure", groupID, DefaultScope, "", trackingID)
+	creds, err := RegisterSystem("Register System Failure", groupID, DefaultScope, "", []string{}, trackingID)
 	assert.Nil(err, "error in public key")
 	assert.NotEmpty(creds)
 
 	// Invalid key not ok
-	creds, err = RegisterSystem("Register System Failure", groupID, DefaultScope, "NotAKey", trackingID)
+	creds, err = RegisterSystem("Register System Failure", groupID, DefaultScope, "NotAKey", []string{}, trackingID)
 	assert.EqualError(err, "error in public key")
 	assert.Empty(creds)
 
 	// Low key length not ok
-	creds, err = RegisterSystem("Register System Failure", groupID, DefaultScope, pubKey, trackingID)
+	creds, err = RegisterSystem("Register System Failure", groupID, DefaultScope, pubKey, []string{}, trackingID)
 	assert.EqualError(err, "error in public key")
 	assert.Empty(creds)
 

--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -722,7 +722,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"client_name\": \"System 1 for group {{group.group_id}}\",\n    \"group_id\": \"{{group.group_id}}\",\n    \"scope\": \"bcda-api\",\n    \"ips\": [\"192.168.0.1/32\", \"2001:db8:a0b:12f0::1/128\"],\n    \"tracking_id\": \"{{tracking_id}}\"\n}"
+					"raw": "{\n    \"client_name\": \"System 1 for group {{group.group_id}}\",\n    \"group_id\": \"{{group.group_id}}\",\n    \"scope\": \"bcda-api\",\n    \"ips\": [\"8.8.8.8\", \"200:1:1:1::1\"],\n    \"tracking_id\": \"{{tracking_id}}\"\n}"
 				},
 				"url": {
 					"raw": "{{scheme}}://{{host}}:{{admin-port}}/system",

--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -571,7 +571,12 @@
 							"                            \"properties\": {",
 							"                                \"id\": { \"type\": \"integer\" },                                ",
 							"                                \"client_name\": { \"type\": \"string\" },",
-							"                                \"client_id\": { \"type\": \"string\" }",
+							"                                \"client_id\": { \"type\": \"string\" },",
+							"                                \"ips\": {",
+							"                                    \"type\": \"array\", \"items\": [",
+							"                                        { \"type\": \"string\" }",
+							"                                    ]",
+							"                                }",
 							"                            }",
 							"                        }",
 							"                    }",
@@ -647,6 +652,11 @@
 							"        \"client_secret\": { \"type\": \"string\" },",
 							"        \"client_name\": { \"type\": \"string\" },",
 							"        \"system_id\": { \"type\": \"string\" },",
+							"        \"ips\": {",
+							"            \"type\": \"array\", \"items\": [",
+							"                { \"type\": \"string\" }",
+							"            ]",
+							"        },",
 							"        \"expires_at\": { \"type\": \"string\", \"format\": \"time\" }",
 							"    }",
 							"};",
@@ -712,7 +722,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"client_name\": \"System 1 for group {{group.group_id}}\",\n    \"group_id\": \"{{group.group_id}}\",\n    \"scope\": \"bcda-api\",\n    \"tracking_id\": \"{{tracking_id}}\"\n}"
+					"raw": "{\n    \"client_name\": \"System 1 for group {{group.group_id}}\",\n    \"group_id\": \"{{group.group_id}}\",\n    \"scope\": \"bcda-api\",\n    \"ips\": [\"192.168.0.1/32\", \"2001:db8:a0b:12f0::1/128\"],\n    \"tracking_id\": \"{{tracking_id}}\"\n}"
 				},
 				"url": {
 					"raw": "{{scheme}}://{{host}}:{{admin-port}}/system",
@@ -1198,7 +1208,7 @@
 					"listen": "test",
 					"script": {
 						"id": "20ed753f-bd64-4270-9993-305d4efc1372",
-					  	"exec": [
+						"exec": [
 							"var schema = {",
 							"    \"properties\": {",
 							"        \"client_id\": { \"type\": \"string\" },",
@@ -1232,7 +1242,7 @@
 							"pm.environment.set(\"client_id\", respJson.client_id);  ",
 							"pm.environment.set(\"client_secret\", respJson.client_secret);",
 							""
-					  	],
+						],
 						"type": "text/javascript"
 					}
 				}


### PR DESCRIPTION
### Fixes [BCDA-2378](https://jira.cms.gov/browse/BCDA-2378)
When ACO's are getting their credentials (registering their systems) through ACO-MS, the process of onboarding should be fully automated.  To make that possible, BCDA needs a piece of information from the ACO that SSAS is not currently providing: what IP address (or addresses) will their system(s) be coming from?

This PR is the first step in getting that piece of information to BCDA: collection and storage.

### Proposed Changes
- Accept an array of IP's during system registration
- Show the IP's
   - In the system registration response
   - In the list of groups (which also shows systems)

How do we fit all the CRUD operations into these minor changes?
* **Create** - system IP's are added during system creation
* **Read** - system IP's are listed with groups
* **Update** - no system update endpoint currently exists, and ACO-MS would not use a dedicated IP update endpoint. If the IP addresses must change, the current system can be deleted and new system can be created.
* **Delete** - IP's are no longer considered valid when the associated system is deleted

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [x] new data stored or transmitted
The ACOs' IP addresses are newly stored and transmitted.
- [ ] security checklist is completed for this change
In [BCDA-2422](https://jira.cms.gov/browse/BCDA-2422) we will be discussing the larger question of automating IP whitelisting.  The first IP's would start being collected in February.  This PR serves to document the proposed main interface.
- [ ] requires more information or team discussion to evaluate security implications

### Migration Strategy
This PR requires a new table.  Before deploying this code, the SSAS database schema migration for version 4 should be run from Jenkins.

### Acceptance Validation
#### System creation request and response
<img width="868" alt="Screen Shot 2019-11-21 at 9 16 37 AM" src="https://user-images.githubusercontent.com/2533561/69346267-82caf200-0c40-11ea-907a-b7b1fa0fa926.png">

#### Group listing showing IP's
<img width="868" alt="Screen Shot 2019-11-21 at 9 17 05 AM" src="https://user-images.githubusercontent.com/2533561/69346268-83638880-0c40-11ea-999c-2da41fc17fc5.png">

### Feedback Requested
- Should the IP's be stored differently?
- Do the changes to API requests/responses look appropriate, or should we consider alternate naming/structure?
- Do we need further automate testing?