### PR TITLE
BCDA-2378a Update database migration query syntax

### DIFF
--- a/db/migrations/000001_initial_schema.up.sql
+++ b/db/migrations/000001_initial_schema.up.sql
@@ -10,7 +10,6 @@ CREATE TABLE public.blacklist_entries (
 );
 ALTER TABLE public.blacklist_entries OWNER TO postgres;
 CREATE SEQUENCE public.blacklist_entries_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -30,7 +29,6 @@ CREATE TABLE public.encryption_keys (
 );
 ALTER TABLE public.encryption_keys OWNER TO postgres;
 CREATE SEQUENCE public.encryption_keys_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -50,7 +48,6 @@ CREATE TABLE public.groups (
 );
 ALTER TABLE public.groups OWNER TO postgres;
 CREATE SEQUENCE public.groups_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -69,7 +66,6 @@ CREATE TABLE public.secrets (
 );
 ALTER TABLE public.secrets OWNER TO postgres;
 CREATE SEQUENCE public.secrets_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -91,7 +87,6 @@ CREATE TABLE public.systems (
 );
 ALTER TABLE public.systems OWNER TO postgres;
 CREATE SEQUENCE public.systems_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE

--- a/db/migrations/000001_initial_schema.up.sql
+++ b/db/migrations/000001_initial_schema.up.sql
@@ -8,14 +8,12 @@ CREATE TABLE public.blacklist_entries (
                                           entry_date bigint NOT NULL,
                                           cache_expiration bigint NOT NULL
 );
-ALTER TABLE public.blacklist_entries OWNER TO postgres;
 CREATE SEQUENCE public.blacklist_entries_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.blacklist_entries_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.blacklist_entries_id_seq OWNED BY public.blacklist_entries.id;
 
 
@@ -27,14 +25,12 @@ CREATE TABLE public.encryption_keys (
                                         body text,
                                         system_id integer
 );
-ALTER TABLE public.encryption_keys OWNER TO postgres;
 CREATE SEQUENCE public.encryption_keys_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.encryption_keys_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.encryption_keys_id_seq OWNED BY public.encryption_keys.id;
 
 CREATE TABLE public.groups (
@@ -46,14 +42,12 @@ CREATE TABLE public.groups (
                                x_data text,
                                data jsonb
 );
-ALTER TABLE public.groups OWNER TO postgres;
 CREATE SEQUENCE public.groups_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.groups_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.groups_id_seq OWNED BY public.groups.id;
 
 CREATE TABLE public.secrets (
@@ -64,14 +58,12 @@ CREATE TABLE public.secrets (
                                 hash text,
                                 system_id integer
 );
-ALTER TABLE public.secrets OWNER TO postgres;
 CREATE SEQUENCE public.secrets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.secrets_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.secrets_id_seq OWNED BY public.secrets.id;
 
 CREATE TABLE public.systems (
@@ -85,14 +77,12 @@ CREATE TABLE public.systems (
                                 client_name text,
                                 api_scope text
 );
-ALTER TABLE public.systems OWNER TO postgres;
 CREATE SEQUENCE public.systems_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.systems_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.systems_id_seq OWNED BY public.systems.id;
 
 ALTER TABLE ONLY public.blacklist_entries ALTER COLUMN id SET DEFAULT nextval('public.blacklist_entries_id_seq'::regclass);

--- a/db/migrations/000004_ips.up.sql
+++ b/db/migrations/000004_ips.up.sql
@@ -10,7 +10,6 @@ CREATE TABLE public.ips (
 );
 ALTER TABLE public.ips OWNER TO postgres;
 CREATE SEQUENCE public.ips_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE

--- a/db/migrations/000004_ips.up.sql
+++ b/db/migrations/000004_ips.up.sql
@@ -8,14 +8,12 @@ CREATE TABLE public.ips (
     address INET NOT NULL,
     system_id integer NOT NULL
 );
-ALTER TABLE public.ips OWNER TO postgres;
 CREATE SEQUENCE public.ips_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE public.ips_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.ips_id_seq OWNED BY public.ips.id;
 ALTER TABLE ONLY public.ips ALTER COLUMN id SET DEFAULT nextval('public.ips_id_seq'::regclass);
 ALTER TABLE ONLY public.ips


### PR DESCRIPTION
### Fixes [BCDA-2378](https://jira.cms.gov/browse/BCDA-2378)
Our development and testing is done against a different version of Postgres than we are running in AWS RDS.  The migration script for the previous PR #18 passed testing locally and in Travis, but failed on RDS.  This PR updates the script to a syntax that runs in all environments.

Recommendation for future database migrations: test in `dev` before writing the PR.

### Proposed Changes
- Update SQL migration script for schema version 4
- Retroactively update SQL migration scripts for version 1

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This syntax change should provide no net change in security.

### Acceptance Validation
#### Changes applied to `dev`
<img width="789" alt="Screen Shot 2019-11-22 at 11 21 38 AM" src="https://user-images.githubusercontent.com/2533561/69442297-51bef000-0d1a-11ea-8bf0-c6fddcdd45c2.png">


### Feedback Requested
- Any concerns?