### PR TITLE
BCDA-2543 Faster listGroups()

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -92,7 +92,7 @@ func ListGroups(trackingID string) (list GroupList, err error) {
 	groups := []GroupSummary{}
 	db := GetGORMDbConnection()
 	defer Close(db)
-	err = db.Preload("Systems").Find(&groups).Error
+	err = db.Preload("Systems").Where("deleted_at IS NULL").Find(&groups).Error
 	if err != nil {
 		event.Help = err.Error()
 		OperationFailed(event)

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -5,25 +5,30 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/jinzhu/gorm"
 	"strconv"
 	"time"
-
-	"github.com/jinzhu/gorm"
 )
 
 type Group struct {
 	gorm.Model
-	GroupID string    `gorm:"unique;not null" json:"group_id"`
-	XData   string    `gorm:"type:text" json:"xdata"`
-	Data    GroupData `gorm:"type:jsonb" json:"data"`
+	GroupID		string		`gorm:"unique;not null" json:"group_id"`
+	XData		string		`gorm:"type:text" json:"xdata"`
+	Data		GroupData	`gorm:"type:jsonb" json:"data"`
+	Systems		[]System	`gorm:"foreignkey:GID"`
 }
 
 type SystemSummary struct {
 	ID        	uint    	`json:"id"`
+	GID			uint		`json:"-"`
 	ClientName	string		`json:"client_name"`
 	ClientID	string  	`json:"client_id"`
 	IPs       	[]string	`json:"ips,omitempty"`
 	UpdatedAt 	time.Time	`json:"updated_at"`
+}
+
+func (SystemSummary) TableName() string {
+	return "systems"
 }
 
 type GroupSummary struct {
@@ -31,13 +36,17 @@ type GroupSummary struct {
 	GroupID   string          `json:"group_id"`
 	XData     string          `json:"xdata"`
 	CreatedAt time.Time       `json:"created_at"`
-	Systems   []SystemSummary `json:"systems"`
+	Systems   []SystemSummary `json:"systems" gorm:"foreignkey:GID"`
+}
+
+func (GroupSummary) TableName() string {
+	return "groups"
 }
 
 type GroupList struct {
-	Count      int            `json:"count"`
-	ReportedAt time.Time      `json:"reported_at"`
-	Groups     []GroupSummary `json:"groups"`
+	Count      int				`json:"count"`
+	ReportedAt time.Time		`json:"reported_at"`
+	Groups     []GroupSummary	`json:"groups"`
 }
 
 func CreateGroup(gd GroupData) (Group, error) {
@@ -80,10 +89,10 @@ func ListGroups(trackingID string) (list GroupList, err error) {
 	event := Event{Op: "ListGroups", TrackingID: trackingID}
 	OperationStarted(event)
 
-	groups := []Group{}
+	groups := []GroupSummary{}
 	db := GetGORMDbConnection()
 	defer Close(db)
-	err = db.Find(&groups).Error
+	err = db.Preload("Systems").Find(&groups).Error
 	if err != nil {
 		event.Help = err.Error()
 		OperationFailed(event)
@@ -92,31 +101,7 @@ func ListGroups(trackingID string) (list GroupList, err error) {
 
 	list.Count = len(groups)
 	list.ReportedAt = time.Now()
-	for _, group := range groups {
-		gs := GroupSummary{}
-		gs.ID = group.ID
-		gs.GroupID = group.GroupID
-		gs.XData = group.XData
-		gs.CreatedAt = group.CreatedAt
-
-		var systems []System
-		systems, err = GetSystemsByGroupID(group.ID)
-		if err != nil {
-			return
-		}
-		for _, system := range systems {
-			ss := SystemSummary{}
-			ss.ID = system.ID
-			ss.ClientName = system.ClientName
-			ss.ClientID = system.ClientID
-			ss.IPs, _ = system.GetIPs()
-			ss.UpdatedAt = system.UpdatedAt
-
-			gs.Systems = append(gs.Systems, ss)
-		}
-
-		list.Groups = append(list.Groups, gs)
-	}
+	list.Groups = groups
 
 	OperationSucceeded(event)
 	return list, nil

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -20,7 +20,7 @@ type Group struct {
 
 type SystemSummary struct {
 	ID        	uint    	`json:"id"`
-	GID			uint		`json:"-"`
+	GID        	uint		`json:"-"`
 	ClientName	string		`json:"client_name"`
 	ClientID	string  	`json:"client_id"`
 	IPs       	[]string	`json:"ips,omitempty"`
@@ -44,7 +44,7 @@ func (GroupSummary) TableName() string {
 }
 
 type GroupList struct {
-	Count      int				`json:"count"`
+	Count      int        		`json:"count"`
 	ReportedAt time.Time		`json:"reported_at"`
 	Groups     []GroupSummary	`json:"groups"`
 }


### PR DESCRIPTION
### Fixes [BCDA-2543](https://jira.cms.gov/browse/BCDA-2543)
In our `test` environment with several hundred groups, `GET /group` (which calls `listGroups()`) is timing out.  This PR reduces the number of database queries in order to speed it up.

### Proposed Changes
- Use Gorm's preload feature to reduce the queries from about n + 1 down to 2.
- Have Gorm directly load the structs we'll be responding with, rather than copying data from `Group{}` to `GroupSummary{}` and from `System{}` to `SystemSummary{}`

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

These database query changes do not alter parameters or allow SQL injection, and improve speed significantly.

### Acceptance Validation
In the local development environment with more than 500 groups, the endpoint was sped up from >12s to ~220ms.
#### Before
![Screen Shot 2019-12-31 at 12 25 32 PM](https://user-images.githubusercontent.com/2533561/71628947-bd716400-2bc8-11ea-9dfe-edc13ac01b8d.png)

#### After
![Screen Shot 2019-12-31 at 12 24 15 PM](https://user-images.githubusercontent.com/2533561/71628949-bfd3be00-2bc8-11ea-9216-e21551010b32.png)


### Feedback Requested
All improvements welcome