### PR TITLE
BCDA-2593 Feature: Add ACO ID to credential events

### DIFF
--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -352,7 +352,7 @@ func deactivateSystemCredentials(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusNotFound, "invalid system ID")
 		return
 	}
-	err = system.DeactivateSecrets()
+	err = system.RevokeSecret(systemID)
 
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "invalid system ID")

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -108,7 +108,7 @@ func (system *System) SaveSecret(hashedSecret string) error {
 		SystemID: system.ID,
 	}
 
-	if err := system.DeactivateSecrets(); err != nil {
+	if err := system.deactivateSecrets(); err != nil {
 		return err
 	}
 
@@ -142,11 +142,38 @@ func (system *System) GetSecret() (string, error) {
 }
 
 /*
+	RevokeSecret revokes a system's secret
+ */
+func (system *System) RevokeSecret(trackingID string) error {
+	revokeCredentialsEvent := Event{Op: "RevokeCredentials", TrackingID: trackingID, ClientID: system.ClientID}
+	OperationStarted(revokeCredentialsEvent)
+
+	xdata, err := XDataFor(*system)
+	if err != nil {
+		revokeCredentialsEvent.Help = fmt.Sprintf("could not get group XData for clientID %s: %s", system.ClientID, err.Error())
+		OperationFailed(revokeCredentialsEvent)
+		return fmt.Errorf("unable to find group for clientID %s: %s", system.ClientID, err.Error())
+	}
+
+	err = system.deactivateSecrets()
+	if err != nil {
+		revokeCredentialsEvent.Help = "unable to revoke credentials for clientID " + system.ClientID
+		OperationFailed(revokeCredentialsEvent)
+		return fmt.Errorf("unable to revoke credentials for clientID %s: %s", system.ClientID, err.Error())
+	}
+
+	revokeCredentialsEvent.Help = fmt.Sprintf("secret reset in group %s with XData: %s", system.GroupID, xdata)
+	OperationSucceeded(revokeCredentialsEvent)
+	return nil
+}
+
+/*
 	DeactivateSecrets soft deletes secrets associated with the system.
 */
-func (system *System) DeactivateSecrets() error {
+func (system *System) deactivateSecrets() error {
 	db := GetGORMDbConnection()
 	defer Close(db)
+
 	err := db.Where("system_id = ?", system.ID).Delete(&Secret{}).Error
 	if err != nil {
 		return fmt.Errorf("unable to soft delete previous secrets for clientID %s: %s", system.ClientID, err.Error())
@@ -448,6 +475,7 @@ func RegisterSystem(clientName string, groupID string, scope string, publicKeyPE
 	creds.IPs = ips
 	creds.ExpiresAt = time.Now().Add(CredentialExpiration)
 
+	regEvent.Help = fmt.Sprintf("system registered in group %s with XData: %s", group.GroupID, group.XData)
 	OperationSucceeded(regEvent)
 	return creds, nil
 }
@@ -458,8 +486,6 @@ func XDataFor(system System) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("no group for system %d; %s", system.ID, err)
 	}
-	Logger.Info("group xdata '", group, "'")
-	// strconv.Unquote here?
 	return group.XData, nil
 }
 
@@ -576,6 +602,13 @@ func (system *System) ResetSecret(trackingID string) (Credentials, error) {
 	newSecretEvent := Event{Op: "ResetSecret", TrackingID: trackingID, ClientID: system.ClientID}
 	OperationStarted(newSecretEvent)
 
+	xdata, err := XDataFor(*system)
+	if err != nil {
+		newSecretEvent.Help = fmt.Sprintf("could not get group XData for clientID %s: %s", system.ClientID, err.Error())
+		OperationFailed(newSecretEvent)
+		return creds, errors.New("internal system error")
+	}
+
 	secretString, err := GenerateSecret()
 	if err != nil {
 		newSecretEvent.Help = fmt.Sprintf("could not reset secret for clientID %s: %s", system.ClientID, err.Error())
@@ -597,6 +630,7 @@ func (system *System) ResetSecret(trackingID string) (Credentials, error) {
 		return creds, errors.New("internal system error")
 	}
 
+	newSecretEvent.Help = fmt.Sprintf("secret reset in group %s with XData: %s", system.GroupID, xdata)
 	OperationSucceeded(newSecretEvent)
 
 	creds.SystemID = fmt.Sprint(system.ID)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -162,7 +162,7 @@ func (system *System) RevokeSecret(trackingID string) error {
 		return fmt.Errorf("unable to revoke credentials for clientID %s: %s", system.ClientID, err.Error())
 	}
 
-	revokeCredentialsEvent.Help = fmt.Sprintf("secret reset in group %s with XData: %s", system.GroupID, xdata)
+	revokeCredentialsEvent.Help = fmt.Sprintf("secret revoked in group %s with XData: %s", system.GroupID, xdata)
 	OperationSucceeded(revokeCredentialsEvent)
 	return nil
 }

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -601,7 +601,7 @@ func (s *SystemsTestSuite) TestSaveSecret() {
 	assert.Nil(err)
 }
 
-func (s *SystemsTestSuite) TestDeactivateSecrets() {
+func (s *SystemsTestSuite) TestRevokeSecrets() {
 	group := Group{GroupID: "test-deactivate-secrets-group"}
 	s.db.Create(&group)
 	system := System{GID: group.ID, ClientID: "test-deactivate-secrets-client"}
@@ -613,7 +613,7 @@ func (s *SystemsTestSuite) TestDeactivateSecrets() {
 	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
 	assert.NotEmpty(s.T(), systemSecrets)
 
-	err := system.DeactivateSecrets()
+	err := system.RevokeSecret(string(system.ID))
 	assert.Nil(s.T(), err)
 	s.db.Find(&systemSecrets, "system_id = ?", system.ID)
 	assert.Empty(s.T(), systemSecrets)


### PR DESCRIPTION
### Fixes [BCDA-2593](https://jira.cms.gov/browse/BCDA-2593)
In order to gain more insight into security-related events in SSAS, we wish to include the CMS ID in credential and system-related events.  By design, SSAS is not aware of the CMS ID; it's part of a packet of information (`Group.XData`) forwarded from ACO-MS to the ACO API inside an ACO's token.  To maintain this ignorance, we will log the entire contents of `Group.XData` rather than parsing the CMS ID from it.

### Proposed Changes
- For selected events, retrieve and log the associated `Group.XData`

### Change Details
- Refactor `system.DeactivateSecret()` so that it's clear when a log-able event is happening
- Define a field in Splunk that parses the CMS ID from `Group.XData` (see bottom of screenshot below)

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This change logs (for the first time) the contents of `Group.XData`, which is by design ignored by SSAS but meaningful to its participating system (the ACO API).  This data is present in every JWT created by SSAS, and therefore must contain non-sensitive data.

### Acceptance Validation
<img width="917" alt="Screen Shot 2020-01-30 at 11 09 21 PM" src="https://user-images.githubusercontent.com/2533561/73511996-e0548b00-43b5-11ea-8eb8-aff112dbdf3e.png">

Note the new Splunk field that captures the ACO ID from the `msg` field

#### Splunk->Slack alerts in `dev` using the new log data
![Screen Shot 2020-01-31 at 11 57 05 AM](https://user-images.githubusercontent.com/2533561/73560235-93f46400-4424-11ea-95c6-af1a81b7a50f.png)
![Screen Shot 2020-01-31 at 11 56 38 AM](https://user-images.githubusercontent.com/2533561/73560239-93f46400-4424-11ea-9fca-325f7def2dd0.png)
![Screen Shot 2020-01-31 at 12 07 23 PM](https://user-images.githubusercontent.com/2533561/73560940-fef26a80-4425-11ea-86d5-3edca530e762.png)


### Feedback Requested
- Should the wording be different in the logs?
- All enhancements welcome