### PR TITLE
BCDA-2674 Security: Log token creation and add to SSAS dashboard

### DIFF
--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -457,6 +457,7 @@ func token(w http.ResponseWriter, r *http.Request) {
 	}
 
 	trackingID := uuid.NewRandom().String()
+
 	data, err := ssas.XDataFor(system)
 	ssas.Logger.Infof("public.api.token: XDataFor(%d) returned '%s'", system.ID, data)
 	if err != nil {
@@ -473,6 +474,8 @@ func token(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
+
+	event.Help = fmt.Sprintf("token creation in group %s with XData: %s", system.GroupID, data)
 
 	// https://tools.ietf.org/html/rfc6749#section-5.1
 	// expires_in is duration in seconds

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -475,7 +475,7 @@ func token(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event.Help = fmt.Sprintf("token creation in group %s with XData: %s", system.GroupID, data)
+	event.Help = fmt.Sprintf("token created in group %s with XData: %s", system.GroupID, data)
 
 	// https://tools.ietf.org/html/rfc6749#section-5.1
 	// expires_in is duration in seconds


### PR DESCRIPTION
### Fixes [BCDA-2674](https://jira.cms.gov/browse/BCDA-2674)
Our team would like to see the number of tokens created during a given period.  This PR adds the necessary log data, so that a query can be added to the Splunk SSAS dashboards.

### Proposed Changes
- Log the CMS ID during token creation
- Add a query to the Splunk SSAS dashboards

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No "new" data is being logged; the CMS ID (ACO ID) is already logged in other events when a token is used.

### Acceptance Validation
#### See column on right
![Screen Shot 2020-02-06 at 2 34 04 PM](https://user-images.githubusercontent.com/2533561/73972680-3ca43700-48ef-11ea-8399-e6ad39c931e8.png)


### Feedback Requested
- Any suggestions?