### PR TITLE
BCDA-2597 Feature: Log raw group request in SSAS

### DIFF
--- a/db/migrations/migrations_test.go
+++ b/db/migrations/migrations_test.go
@@ -126,20 +126,20 @@ func up2(t *testing.T) {
 		assert.Nil(t, err)
 
 		g2.GroupID = "T0001"
-		group2, err := ssas.CreateGroup(g2)
+		group2, err := ssas.CreateGroup(g2, ssas.RandomHexID())
 		require.Nil(t, err)
 		assert.Equal(t, group2.GroupID, "T0001")
 
 		g3.GroupID = "T0001"
 		// We still don't let two undeleted groups have the same group_id . . .
-		group3, err := ssas.CreateGroup(g3)
+		group3, err := ssas.CreateGroup(g3, ssas.RandomHexID())
 		assert.NotNil(t, err)
 
 		err = ssas.DeleteGroup(strconv.Itoa(int(group2.ID)))
 		assert.Nil(t, err)
 
 		// . . . but one can now share the same group_id as a deleted group
-		group3, err = ssas.CreateGroup(g3)
+		group3, err = ssas.CreateGroup(g3, ssas.RandomHexID())
 		require.Nil(t, err)
 		assert.Equal(t, group3.GroupID, "T0001")
 		assert.NotEqual(t, group1.ID, group3.ID)

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -49,8 +49,8 @@ type GroupList struct {
 	Groups     []GroupSummary	`json:"groups"`
 }
 
-func CreateGroup(gd GroupData) (Group, error) {
-	event := Event{Op: "CreateGroup", TrackingID: gd.GroupID}
+func CreateGroup(gd GroupData, trackingID string) (Group, error) {
+	event := Event{Op: "CreateGroup", TrackingID: trackingID}
 	OperationStarted(event)
 
 	if gd.GroupID == "" {

--- a/ssas/groups_test.go
+++ b/ssas/groups_test.go
@@ -68,7 +68,7 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	gd := GroupData{}
 	err := json.Unmarshal([]byte(fmt.Sprintf(SampleGroup, gid, SampleXdata)), &gd)
 	assert.Nil(s.T(), err)
-	g, err := CreateGroup(gd)
+	g, err := CreateGroup(gd, RandomHexID())
 
 	require.Nil(s.T(), err)
 	require.NotNil(s.T(), g)
@@ -95,7 +95,7 @@ func (s *GroupsTestSuite) TestCreateGroup() {
 	err = CleanDatabase(g)
 	assert.Nil(s.T(), err)
 	gd.GroupID = ""
-	_, err = CreateGroup(gd)
+	_, err = CreateGroup(gd, RandomHexID())
 	assert.EqualError(s.T(), err, "group_id cannot be blank")
 }
 
@@ -106,13 +106,13 @@ func (s *GroupsTestSuite) TestListGroups() {
 	gd := GroupData{}
 	err := json.Unmarshal(groupBytes, &gd)
 	require.Nil(s.T(), err)
-	g1, err := CreateGroup(gd)
+	g1, err := CreateGroup(gd, RandomHexID())
 	require.Nil(s.T(), err)
 
 
 	gd.GroupID = RandomHexID()
 	gd.Name = "some-fake-name"
-	g2, err := CreateGroup(gd)
+	g2, err := CreateGroup(gd, RandomHexID())
 	assert.Nil(s.T(), err)
 
 	groupList, err := ListGroups("test-list-groups")
@@ -186,17 +186,17 @@ func (s *GroupsTestSuite) TestGetAuthorizedGroupsForOktaID() {
 	g1 := GroupData{}
 	err := json.Unmarshal(group1bytes, &g1)
 	assert.Nil(s.T(), err)
-	group1, _ := CreateGroup(g1)
+	group1, _ := CreateGroup(g1, RandomHexID())
 
 	g2 := GroupData{}
 	err = json.Unmarshal(group2bytes, &g2)
 	assert.Nil(s.T(), err)
-	group2, _ := CreateGroup(g2)
+	group2, _ := CreateGroup(g2, RandomHexID())
 
 	g3 := GroupData{}
 	err = json.Unmarshal(group3bytes, &g3)
 	assert.Nil(s.T(), err)
-	group3, _ := CreateGroup(g3)
+	group3, _ := CreateGroup(g3, RandomHexID())
 
 	defer s.db.Unscoped().Delete(&group1)
 	defer s.db.Unscoped().Delete(&group2)

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -34,6 +34,8 @@ import (
 		500: serverError
 */
 func createGroup(w http.ResponseWriter, r *http.Request) {
+	ssas.Logger.Infof("Raw request createGroup: %v", r.Body)
+
 	gd := ssas.GroupData{}
 	err := json.NewDecoder(r.Body).Decode(&gd)
 	if err != nil {
@@ -129,6 +131,7 @@ func listGroups(w http.ResponseWriter, r *http.Request) {
 		500: serverError
 */
 func updateGroup(w http.ResponseWriter, r *http.Request) {
+	ssas.Logger.Infof("Raw request updateGroup: %v", r.Body)
 	id := chi.URLParam(r, "id")
 
 	gd := ssas.GroupData{}

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -34,6 +35,10 @@ import (
 		500: serverError
 */
 func createGroup(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	reqBody := r.Body
+	rawReq, _ := ioutil.ReadAll(reqBody)
+
 	gd := ssas.GroupData{}
 	err := json.NewDecoder(r.Body).Decode(&gd)
 	if err != nil {
@@ -41,7 +46,7 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.GroupID, Help: fmt.Sprintf("calling from admin.createGroup(), raw request: %v", gd)})
+	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.GroupID, Help: fmt.Sprintf("calling from admin.createGroup(), raw request: %v", string(rawReq))})
 	g, err := ssas.CreateGroup(gd)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to create group; %s", err))
@@ -130,6 +135,9 @@ func listGroups(w http.ResponseWriter, r *http.Request) {
 */
 func updateGroup(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	defer r.Body.Close()
+	reqBody := r.Body
+	rawReq, _ := ioutil.ReadAll(reqBody)
 
 	gd := ssas.GroupData{}
 	err := json.NewDecoder(r.Body).Decode(&gd)
@@ -138,7 +146,7 @@ func updateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "UpdateGroup", TrackingID: id, Help: fmt.Sprintf("calling from admin.updateGroup(), raw request: %v", gd)})
+	ssas.OperationCalled(ssas.Event{Op: "UpdateGroup", TrackingID: id, Help: fmt.Sprintf("calling from admin.updateGroup(), raw request: %v", string(rawReq))})
 	g, err := ssas.UpdateGroup(id, gd)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to update group; %s", err))

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -35,19 +35,23 @@ import (
 		500: serverError
 */
 func createGroup(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-	reqBody := r.Body
-	rawReq, _ := ioutil.ReadAll(reqBody)
+	trackingID := ssas.RandomHexID()
+	groupEvent := ssas.Event{Op: "CreateGroup", TrackingID: trackingID}
 
+	defer r.Body.Close()
+	body, _ := ioutil.ReadAll(r.Body)
 	gd := ssas.GroupData{}
-	err := json.NewDecoder(r.Body).Decode(&gd)
+	err := json.Unmarshal(body, &gd)
 	if err != nil {
+		groupEvent.Help = fmt.Sprintf("error in request to create group; raw request: %v; error: %v", body, err.Error())
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.GroupID, Help: fmt.Sprintf("calling from admin.createGroup(), raw request: %v", string(rawReq))})
-	g, err := ssas.CreateGroup(gd)
+	groupEvent.Help = fmt.Sprintf("calling from admin.createGroup(), raw request: %v", string(body))
+	ssas.OperationCalled(groupEvent)
+	g, err := ssas.CreateGroup(gd, trackingID)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to create group; %s", err))
 		return
@@ -55,7 +59,8 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 
 	groupJSON, err := json.Marshal(g)
 	if err != nil {
-		ssas.OperationFailed(ssas.Event{Op: "admin.createGroup", TrackingID: gd.GroupID, Help: err.Error()})
+		groupEvent.Help = err.Error()
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -64,7 +69,8 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	_, err = w.Write(groupJSON)
 	if err != nil {
-		ssas.OperationFailed(ssas.Event{Op: "admin.createGroup", TrackingID: gd.GroupID, Help: err.Error()})
+		groupEvent.Help = err.Error()
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusInternalServerError, "internal error")
 	}
 }
@@ -135,18 +141,22 @@ func listGroups(w http.ResponseWriter, r *http.Request) {
 */
 func updateGroup(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	defer r.Body.Close()
-	reqBody := r.Body
-	rawReq, _ := ioutil.ReadAll(reqBody)
+	trackingID := ssas.RandomHexID()
+	groupEvent := ssas.Event{Op: "UpdateGroup", TrackingID: trackingID}
 
+	defer r.Body.Close()
+	body, _ := ioutil.ReadAll(r.Body)
 	gd := ssas.GroupData{}
-	err := json.NewDecoder(r.Body).Decode(&gd)
+	err := json.Unmarshal(body, &gd)
 	if err != nil {
+		groupEvent.Help = fmt.Sprintf("error in request to create group; raw request: %v; error: %v", body, err.Error())
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "UpdateGroup", TrackingID: id, Help: fmt.Sprintf("calling from admin.updateGroup(), raw request: %v", string(rawReq))})
+	groupEvent.Help = fmt.Sprintf("calling from admin.updateGroup(), raw request: %v", string(body))
+	ssas.OperationCalled(groupEvent)
 	g, err := ssas.UpdateGroup(id, gd)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to update group; %s", err))
@@ -155,7 +165,8 @@ func updateGroup(w http.ResponseWriter, r *http.Request) {
 
 	groupJSON, err := json.Marshal(g)
 	if err != nil {
-		ssas.OperationFailed(ssas.Event{Op: "admin.updateGroup", TrackingID: id, Help: err.Error()})
+		groupEvent.Help = err.Error()
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusInternalServerError, "internal error")
 	}
 
@@ -163,7 +174,8 @@ func updateGroup(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(groupJSON)
 	if err != nil {
-		ssas.OperationFailed(ssas.Event{Op: "admin.updateGroup", TrackingID: id, Help: err.Error()})
+		groupEvent.Help = err.Error()
+		ssas.OperationFailed(groupEvent)
 		jsonError(w, http.StatusInternalServerError, "internal error")
 	}
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -34,8 +34,6 @@ import (
 		500: serverError
 */
 func createGroup(w http.ResponseWriter, r *http.Request) {
-	ssas.Logger.Infof("Raw request createGroup: %v", r.Body)
-
 	gd := ssas.GroupData{}
 	err := json.NewDecoder(r.Body).Decode(&gd)
 	if err != nil {
@@ -43,7 +41,7 @@ func createGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.GroupID, Help: "calling from admin.createGroup()"})
+	ssas.OperationCalled(ssas.Event{Op: "CreateGroup", TrackingID: gd.GroupID, Help: fmt.Sprintf("calling from admin.createGroup(), raw request: %v", gd)})
 	g, err := ssas.CreateGroup(gd)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to create group; %s", err))
@@ -131,7 +129,6 @@ func listGroups(w http.ResponseWriter, r *http.Request) {
 		500: serverError
 */
 func updateGroup(w http.ResponseWriter, r *http.Request) {
-	ssas.Logger.Infof("Raw request updateGroup: %v", r.Body)
 	id := chi.URLParam(r, "id")
 
 	gd := ssas.GroupData{}
@@ -141,7 +138,7 @@ func updateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ssas.OperationCalled(ssas.Event{Op: "UpdateGroup", TrackingID: id, Help: "calling from admin.updateGroup()"})
+	ssas.OperationCalled(ssas.Event{Op: "UpdateGroup", TrackingID: id, Help: fmt.Sprintf("calling from admin.updateGroup(), raw request: %v", gd)})
 	g, err := ssas.UpdateGroup(id, gd)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("failed to update group; %s", err))

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -116,12 +116,12 @@ func (s *APITestSuite) TestListGroups() {
 	gd := ssas.GroupData{}
 	err := json.Unmarshal([]byte(testInput1), &gd)
 	assert.Nil(s.T(), err)
-	g1, err := ssas.CreateGroup(gd)
+	g1, err := ssas.CreateGroup(gd, ssas.RandomHexID())
 	assert.Nil(s.T(), err)
 
 	gd.GroupID = g2ID
 	gd.Name = "another-fake-name"
-	g2, err := ssas.CreateGroup(gd)
+	g2, err := ssas.CreateGroup(gd, ssas.RandomHexID())
 	assert.Nil(s.T(), err)
 
 	req := httptest.NewRequest("GET", "/group", nil)
@@ -158,7 +158,7 @@ func (s *APITestSuite) TestUpdateGroup() {
 	gd := ssas.GroupData{}
 	err := json.Unmarshal([]byte(testInput), &gd)
 	assert.Nil(s.T(), err)
-	g, err := ssas.CreateGroup(gd)
+	g, err := ssas.CreateGroup(gd, ssas.RandomHexID())
 	assert.Nil(s.T(), err)
 
 	url := fmt.Sprintf("/group/%v", g.ID)
@@ -218,7 +218,7 @@ func (s *APITestSuite) TestDeleteGroup() {
 	gd := ssas.GroupData{}
 	err := json.Unmarshal(groupBytes, &gd)
 	assert.Nil(s.T(), err)
-	g, err := ssas.CreateGroup(gd)
+	g, err := ssas.CreateGroup(gd, ssas.RandomHexID())
 	assert.Nil(s.T(), err)
 
 	url := fmt.Sprintf("/group/%v", g.ID)

--- a/ssas/service/public/router_test.go
+++ b/ssas/service/public/router_test.go
@@ -37,7 +37,7 @@ func (s *PublicRouterTestSuite) SetupSuite() {
 	gd := ssas.GroupData{}
 	err := json.Unmarshal(groupBytes, &gd)
 	assert.Nil(s.T(), err)
-	s.group, err = ssas.CreateGroup(gd)
+	s.group, err = ssas.CreateGroup(gd, ssas.RandomHexID())
 	if err != nil {
 		s.FailNow("unable to create group: " + err.Error())
 	}


### PR DESCRIPTION
### Fixes [BCDA-2597](https://jira.cms.gov/browse/BCDA-2597)
To address the extra risk of errors at the integration boundary with ACO-MS, we would like to log the raw requests for managing groups.  This will help troubleshoot any future parsing errors.

### Proposed Changes:
- Add logs for creating and updating groups
- Refactor `ssas.CreateGroup()` to accept a tracking ID as a parameter instead of using the group ID, to support logging before parsing the request

### Security Implications:
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

All of the data added to the logs in this PR is already present in the logs and database; this change duplicates the logged data in a different format to ensure that it is auditable in the case of a future bug.

### Acceptance Validation:
#### Logs contain raw request
##### Creating a group
![Screen Shot 2020-02-19 at 11 05 22 PM](https://user-images.githubusercontent.com/2533561/74900706-a8b28080-536e-11ea-9193-4ea1d7f69bf9.png)
##### Editing a group
![Screen Shot 2020-02-19 at 11 05 22 PM](https://user-images.githubusercontent.com/2533561/74900883-224a6e80-536f-11ea-93c2-806feffa71cb.png)

### Feedback Requested:
- Much of the refactoring could be avoided if the tracking ID were to be updated after parsing the JSON request body with no errors.  I felt that treating the tracking ID as immutable was a better choice; do you disagree?
- Are there any other suggestions?