### PR TITLE
BCDA-2692 Feature: Limit groups to one active credential

### DIFF
--- a/ssas/service/admin/router_test.go
+++ b/ssas/service/admin/router_test.go
@@ -21,7 +21,7 @@ type RouterTestSuite struct {
 	group     ssas.Group
 }
 
-func (s *RouterTestSuite) SetupSuite() {
+func resetCreds(s *RouterTestSuite) {
 	assert.Nil(s.T(), ssas.RevokeActiveCreds("admin"))
 
 	id := "31e029ef-0e97-47f8-873c-0e8b7e7f99bf"
@@ -43,6 +43,7 @@ func (s *RouterTestSuite) SetupSuite() {
 }
 
 func (s *RouterTestSuite) SetupTest() {
+	resetCreds(s)
 	s.router = routes()
 }
 

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -47,6 +47,7 @@ func (s *MainTestSuite) TestMainResetCredentials() {
 
 
 func (s *MainTestSuite) TestNewAdminSystem() {
+	assert.Nil(s.T(), ssas.RevokeActiveCreds("admin"))
 	output := captureOutput(func() { newAdminSystem("Main Test System") })
 	assert.NotEqual(s.T(), "", output)
 }

--- a/ssas/service/public/router_test.go
+++ b/ssas/service/public/router_test.go
@@ -70,6 +70,7 @@ func (s *PublicRouterTestSuite) TestTokenRoute() {
 }
 
 func (s *PublicRouterTestSuite) TestRegisterRoute() {
+	assert.Nil(s.T(), s.system.RevokeSecret("testRegisterRoute")) // ensure no active credentials already exist
 	groupIDs := []string{"T1234", "T0001"}
 	_, ts, _ := MintRegistrationToken("test_okta_id", groupIDs)
 	rb := strings.NewReader(`{"client_id":"evil_twin","client_name":"my evil twin","scope":"bcda-api","jwks":{"keys":[{"e":"AAEAAQ","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw","kty":"RSA"}]}}`)
@@ -84,6 +85,7 @@ func (s *PublicRouterTestSuite) TestRegisterRouteNoToken() {
 }
 
 func (s *PublicRouterTestSuite) TestResetRoute() {
+	assert.Nil(s.T(), ssas.RevokeActiveCreds(s.group.GroupID)) // ensure no active credentials already exist
 	groupIDs := []string{"T1234", "T0001"}
 	_, ts, _ := MintRegistrationToken("test_okta_id", groupIDs)
 	rb := strings.NewReader(fmt.Sprintf(`{"client_id":"%s"}`, s.system.ClientID))

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -135,7 +136,7 @@ func (system *System) GetSecret() (string, error) {
 		return "", fmt.Errorf("unable to get hashed secret for clientID %s: %s", system.ClientID, err.Error())
 	}
 
-	if secret.Hash == "" {
+	if strings.TrimSpace(secret.Hash) == "" {
 		return "", fmt.Errorf("stored hash of secret for clientID %s is blank", system.ClientID)
 	}
 
@@ -348,21 +349,25 @@ func RegisterSystem(clientName string, groupID string, scope string, publicKeyPE
 	db := GetGORMDbConnection()
 	defer Close(db)
 
-	// The public key and hashed secret are stored separately in the encryption_keys and secrets tables, requiring
-	// multiple INSERT statements.  To ensure we do not get into an invalid state, wrap the two INSERT statements in a transaction.
-	tx := db.Begin()
-	defer func() {
-		if r := recover(); r != nil {
-			tx.Rollback()
-		}
-	}()
-
 	creds := Credentials{}
 	clientID := uuid.NewRandom().String()
 
 	// The caller of this function should have logged OperationCalled() with the same trackingID
 	regEvent := Event{Op: "RegisterClient", TrackingID: trackingID, ClientID: clientID}
 	OperationStarted(regEvent)
+
+	credCount, err := activeCredsCount(groupID, "")
+	if err != nil {
+		regEvent.Help = "unable to search for active credentials: " + err.Error()
+		OperationFailed(regEvent)
+		return creds, errors.New("internal error")
+	}
+
+	if credCount > 0 {
+		regEvent.Help = "only one set of active credentials permitted"
+		OperationFailed(regEvent)
+		return creds, errors.New(regEvent.Help)
+	}
 
 	if clientName == "" {
 		regEvent.Help = "clientName is required"
@@ -392,6 +397,15 @@ func RegisterSystem(clientName string, groupID string, scope string, publicKeyPE
 		ClientName: clientName,
 		APIScope:   scope,
 	}
+
+	// The public key and hashed secret are stored separately in the encryption_keys and secrets tables, requiring
+	// multiple INSERT statements.  To ensure we do not get into an invalid state, wrap the two INSERT statements in a transaction.
+	tx := db.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
 
 	err = tx.Create(&system).Error
 	if err != nil {
@@ -628,6 +642,19 @@ func (system *System) ResetSecret(trackingID string) (Credentials, error) {
 		return creds, errors.New("internal system error")
 	}
 
+	credCount, err := activeCredsCount(system.GroupID, system.ClientID)
+	if err != nil {
+		newSecretEvent.Help = "unable to search for active credentials: " + err.Error()
+		OperationFailed(newSecretEvent)
+		return creds, errors.New("internal system error")
+	}
+
+	if credCount > 0 {
+		newSecretEvent.Help = "only one set of active credentials permitted"
+		OperationFailed(newSecretEvent)
+		return creds, errors.New(newSecretEvent.Help)
+	}
+
 	secretString, err := GenerateSecret()
 	if err != nil {
 		newSecretEvent.Help = fmt.Sprintf("could not reset secret for clientID %s: %s", system.ClientID, err.Error())
@@ -658,6 +685,40 @@ func (system *System) ResetSecret(trackingID string) (Credentials, error) {
 	creds.ClientName = system.ClientName
 	creds.ExpiresAt = time.Now().Add(CredentialExpiration)
 	return creds, nil
+}
+
+// activeCredsCount returns the number of credentials (secrets) that are currently valid for the provided group ID
+func activeCredsCount(groupID string, ignoredClientID string) (int, error) {
+	count := 0
+
+	systems, err := GetSystemsByGroupIDString(groupID)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, system := range systems {
+		// The secret(s) for this system could be soft-deleted, which would create an error.  Ignore it.
+		secret, _ := system.GetSecret()
+		if strings.TrimSpace(secret) != "" && ignoredClientID != system.ClientID {
+			count += 1
+		}
+	}
+	return count, nil
+}
+
+// RevokeActiveCreds revokes all credentials for the specified GroupID
+func RevokeActiveCreds(groupID string) error {
+	systems, err := GetSystemsByGroupIDString(groupID)
+	if err != nil {
+		return err
+	}
+	for _, system := range systems {
+		err = system.RevokeSecret("ssas.RevokeActiveCreds for GroupID " + groupID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CleanDatabase deletes the given group and associated systems, encryption keys, and secrets.

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -414,6 +414,32 @@ func (s *SystemsTestSuite) TestRegisterSystemSuccess() {
 	assert.Nil(err)
 }
 
+func (s *SystemsTestSuite) TestRegisterSystemOnlyOneSucceeds() {
+	assert := s.Assert()
+
+	pubKey := ""
+	ips := []string{}
+	trackingID := uuid.NewRandom().String()
+	groupID := "T54321"
+	group := Group{GroupID: groupID}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	creds, err := RegisterSystem("Create System Test 1", groupID, DefaultScope, pubKey, ips, trackingID)
+	assert.Nil(err)
+	assert.Equal("Create System Test 1", creds.ClientName)
+	assert.NotEqual("", strings.TrimSpace(creds.ClientSecret))
+
+	creds2, err := RegisterSystem("Create System Test 2", groupID, DefaultScope, pubKey, ips, trackingID)
+	assert.NotNil(err)
+	assert.Equal("", strings.TrimSpace(creds2.ClientSecret))
+
+	err = CleanDatabase(group)
+	assert.Nil(err)
+}
+
 func (s *SystemsTestSuite) TestRegisterSystemMissingData() {
 	assert := s.Assert()
 
@@ -487,12 +513,18 @@ func (s *SystemsTestSuite) TestRegisterSystemIps() {
 		ips, err = GetAllIPs()
 		assert.Nil(err)
 		assert.Contains(ips, address)
+		sys, err := GetSystemByClientID(creds.ClientID)
+		assert.Nil(err)
+		assert.Nil(sys.RevokeSecret("TestRegisterSystemIps " + address))
 	}
 
 	// We have no limit on the number of IP addresses that can be registered with a system
 	creds, err := RegisterSystem("Test system with all good IPs", groupID, DefaultScope, pubKey, goodIps, trackingID)
 	assert.Nil(err, "An array of good IP's should be a allowed, but was not")
 	assert.NotEmpty(creds)
+	sys, err := GetSystemByClientID(creds.ClientID)
+	assert.Nil(err)
+	assert.Nil(sys.RevokeSecret("TestRegisterSystemIps multiple good IP's"))
 
 	for _, address := range badIps {
 		creds, err = RegisterSystem("Test system with " + address, groupID, DefaultScope, pubKey, []string{address}, trackingID)
@@ -526,6 +558,9 @@ func (s *SystemsTestSuite) TestRegisterSystemBadKey() {
 	creds, err := RegisterSystem("Register System Failure", groupID, DefaultScope, "", []string{}, trackingID)
 	assert.Nil(err, "error in public key")
 	assert.NotEmpty(creds)
+	sys, err := GetSystemByClientID(creds.ClientID)
+	assert.Nil(err)
+	assert.Nil(sys.RevokeSecret("TestRegisterSystemBadKey blank public key"))
 
 	// Invalid key not ok
 	creds, err = RegisterSystem("Register System Failure", groupID, DefaultScope, "NotAKey", []string{}, trackingID)
@@ -763,6 +798,39 @@ func (s *SystemsTestSuite) TestGetSystemsByGroupIDWithKnownSystem() {
 	}
 
 	_ = CleanDatabase(g)
+}
+
+func (s *SystemsTestSuite) TestActiveCredsCount() {
+	groupID := "group-activeCredsCount"
+	group := Group{GroupID: groupID}
+	assert.Nil(s.T(), s.db.Create(&group).Error)
+	system1 := System{GID: group.ID, GroupID: groupID, ClientID: "client1-TestActiveCreds"}
+	assert.Nil(s.T(), s.db.Create(&system1).Error)
+	secret1 := Secret{Hash: "foo", SystemID: system1.ID}
+	assert.Nil(s.T(), s.db.Create(&secret1).Error)
+	system2 := System{GID: group.ID, GroupID: groupID, ClientID: "client2-TestActiveCreds"}
+	assert.Nil(s.T(), s.db.Create(&system2).Error)
+	secret2 := Secret{Hash: "foo", SystemID: system2.ID}
+	assert.Nil(s.T(), s.db.Create(&secret2).Error)
+
+	// We shouldn't be able to get to this state, but just in case: the count should be accurate
+	count, err := activeCredsCount(groupID, "")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, count)
+
+	// Soft-deleted secrets should not be counted
+	assert.Nil(s.T(), s.db.Delete(&secret2).Error)
+	count, err = activeCredsCount(groupID, "")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, count)
+
+	// Soft-deleted systems should not be counted
+	assert.Nil(s.T(), s.db.Delete(&system1).Error)
+	count, err = activeCredsCount(groupID, "")
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 0, count)
+
+	_ = CleanDatabase(group)
 }
 
 func TestSystemsTestSuite(t *testing.T) {

--- a/test/postman_test/SSAS.postman_collection.json
+++ b/test/postman_test/SSAS.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "67811aee-ccef-458e-8225-6c187f9f3376",
+		"_postman_id": "e13991c5-16bb-43cb-b94c-d7390af576e6",
 		"name": "SSAS",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -377,6 +377,121 @@
 			"response": []
 		},
 		{
+			"name": "admin create system with public key, 201",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "fc625fc2-e25e-4fd2-a110-fc1528839ca7",
+						"exec": [
+							"pm.test(\"response is 201 and returns json\", function () {",
+							"    pm.response.to.have.status(201);",
+							"",
+							"    const schema = {",
+							"        \"system_id\": {\"type\": \"string\"},",
+							"        \"client_id\": {\"type\": \"string\"},",
+							"        \"client_secret\": {\"type\": \"string\"},",
+							"        \"client_name\": {\"type\": \"string\"},",
+							"        \"expires_at\": {\"type\": \"string\"},",
+							"    };",
+							"    var respJson = pm.response.json();",
+							"    ",
+							"    pm.test(\"schema is valid\", function() {",
+							"        pm.expect(tv4.validate(respJson, schema)).to.be.true;",
+							"    });",
+							"    ",
+							"    pm.environment.set(\"system-id\", respJson.system_id);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"client_name\": \"Test Client\",\n    \"group_id\": \"fake-id\",\n    \"scope\": \"bcda-api\",\n    \"public_key\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\\nHwIDAQAB\\n-----END PUBLIC KEY-----\",\n    \"tracking_id\": \"T00000\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}:{{admin-port}}/system",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{admin-port}}",
+					"path": [
+						"system"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "admin delete credentials, 200",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "fc625fc2-e25e-4fd2-a110-fc1528839ca7",
+						"exec": [
+							"pm.test(\"response is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{scheme}}://{{host}}:{{admin-port}}/system/{{system-id}}/credentials",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{admin-port}}",
+					"path": [
+						"system",
+						"{{system-id}}",
+						"credentials"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "admin create system, 201",
 			"event": [
 				{
@@ -441,30 +556,25 @@
 			"response": []
 		},
 		{
-			"name": "admin create system with public key, 201",
+			"name": "admin create system, 400 credentials already exist",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"id": "fc625fc2-e25e-4fd2-a110-fc1528839ca7",
 						"exec": [
-							"pm.test(\"response is 201 and returns json\", function () {",
-							"    pm.response.to.have.status(201);",
+							"pm.test(\"response is 400 and returns json\", function () {",
+							"    pm.response.to.have.status(400);",
 							"",
 							"    const schema = {",
-							"        \"system_id\": {\"type\": \"string\"},",
-							"        \"client_id\": {\"type\": \"string\"},",
-							"        \"client_secret\": {\"type\": \"string\"},",
-							"        \"client_name\": {\"type\": \"string\"},",
-							"        \"expires_at\": {\"type\": \"string\"},",
+							"        \"error\": {\"type\": \"string\"},",
+							"        \"error_description\": {\"type\": \"string\"},",
 							"    };",
 							"    var respJson = pm.response.json();",
 							"    ",
 							"    pm.test(\"schema is valid\", function() {",
 							"        pm.expect(tv4.validate(respJson, schema)).to.be.true;",
 							"    });",
-							"    ",
-							"    pm.environment.set(\"system-id\", respJson.system_id);",
 							"});"
 						],
 						"type": "text/javascript"
@@ -483,7 +593,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"client_name\": \"Test Client\",\n    \"group_id\": \"fake-id\",\n    \"scope\": \"bcda-api\",\n    \"public_key\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L\\nI8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK\\n/CBpuKcnU3LhU8JEi7u/db7J4lJlh6evjdKVKlMuhPcljnIKAiGcWln3zwYrFCeL\\ncN0aTOt4xnQpm8OqHawJ18y0WhsWT+hf1DeBDWvdfRuAPlfuVtl3KkrNYn1yqCgQ\\nlT6v/WyzptJhSR1jxdR7XLOhDGTZUzlHXh2bM7sav2n1+sLsuCkzTJqWZ8K7k7cI\\nXK354CNpCdyRYUAUvr4rORIAUmcIFjaR3J4y/Dh2JIyDToOHg7vjpCtNnNoS+ON2\\nHwIDAQAB\\n-----END PUBLIC KEY-----\",\n    \"tracking_id\": \"T00000\"\n}",
+					"raw": "{\n    \"client_name\": \"Test Client 2\",\n    \"group_id\": \"fake-id\",\n    \"scope\": \"bcda-api\",\n    \"tracking_id\": \"T00001\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5448aa97-6ff1-405b-982b-9600e949ffcb",
+		"_postman_id": "f9000b48-d103-4254-860b-ecde72be8f12",
 		"name": "SSAS Smoke Test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -733,6 +733,63 @@
 					"port": "{{admin-port}}",
 					"path": [
 						"system"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "revoke system credentials",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "20ed753f-bd64-4270-9993-305d4efc1372",
+						"exec": [
+							"pm.test(\"Response is 'ok'\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "{{adminClientSecret}}",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "{{adminClientId}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "{{scheme}}://{{host}}:{{admin-port}}/system/{{system_id}}/credentials",
+					"protocol": "{{scheme}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{admin-port}}",
+					"path": [
+						"system",
+						"{{system_id}}",
+						"credentials"
 					]
 				}
 			},

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -31,7 +31,7 @@ DATABASE_URL=$TEST_DB_URL DEBUG=true go run github.com/CMSgov/bcda-ssas-app/ssas
 echo "Successfully loaded SSAS fixture data"
 
 echo "Running SSAS unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --format standard-verbose --debug --junitfile test_results/${timestamp}/junit.xml -- -race ./ssas/... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --debug --junitfile test_results/${timestamp}/junit.xml -- -p 1 -race ./ssas/... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -31,7 +31,7 @@ DATABASE_URL=$TEST_DB_URL DEBUG=true go run github.com/CMSgov/bcda-ssas-app/ssas
 echo "Successfully loaded SSAS fixture data"
 
 echo "Running SSAS unit tests and placing results/coverage in test_results/${timestamp} on host..."
-DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --debug --junitfile test_results/${timestamp}/junit.xml -- -race ./ssas/... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
+DATABASE_URL=$TEST_DB_URL QUEUE_DATABASE_URL=$TEST_DB_URL gotestsum --format standard-verbose --debug --junitfile test_results/${timestamp}/junit.xml -- -race ./ssas/... -coverprofile test_results/${timestamp}/testcoverage.out 2>&1 | tee test_results/${timestamp}/testresults.out
 go tool cover -func test_results/${timestamp}/testcoverage.out > test_results/${timestamp}/testcov_byfunc.out
 echo TOTAL COVERAGE:  $(tail -1 test_results/${timestamp}/testcov_byfunc.out | head -1)
 go tool cover -html=test_results/${timestamp}/testcoverage.out -o test_results/${timestamp}/testcoverage.html


### PR DESCRIPTION
### Fixes [BCDA-2692](https://jira.cms.gov/browse/BCDA-2692)
For initial production, we are limiting each group to one active credential.

### Proposed Changes
- Check for already active credentials at system creation and credential rotation.  Credential rotation will permit rotation of a currently active credential and reactivation if all credentials are currently revoked, but not reactivation if another credential is currently active.
- Update unit and Postman tests to comply with the new constraint

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
https://confluence.cms.gov/display/BCDA/20-02-10%3A+Limit+ACO%27s+to+one+active+credential+Security+Checklist
- [ ] requires more information or team discussion to evaluate security implications

This is a change in quantity of credentials, not in the process of creating/logging/managing them.

### Acceptance Validation
[x] This branch has been [deployed to `dev`](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/1593/)

New unit and Postman tests testing the limitation function.
![Screen Shot 2020-02-14 at 3 08 45 PM](https://user-images.githubusercontent.com/2533561/74563978-f036a800-4f3b-11ea-9188-bce9392e9cb6.png)

### Feedback Requested
- Do we need further tests?
- Is there some way in which this change could put the ACO in a locked-out state, unable to get new credentials?