### PR TITLE
BCDA-2664 Feature: JSON-compliant API responses

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -78,7 +78,7 @@ func CreateGroup(gd GroupData, trackingID string) (Group, error) {
 	if err != nil {
 		event.Help = err.Error()
 		OperationFailed(event)
-		return Group{}, err
+		return Group{}, fmt.Errorf("group violates uniqueness or other constraints")
 	}
 
 	OperationSucceeded(event)
@@ -131,7 +131,7 @@ func UpdateGroup(id string, gd GroupData) (Group, error) {
 	if err != nil {
 		event.Help = err.Error()
 		OperationFailed(event)
-		return Group{}, err
+		return Group{}, fmt.Errorf("group failed to meet database constraints")
 	}
 
 	OperationSucceeded(event)
@@ -155,7 +155,7 @@ func DeleteGroup(id string) error {
 	if err != nil {
 		event.Help = err.Error()
 		OperationFailed(event)
-		return err
+		return fmt.Errorf("database error")
 	}
 
 	OperationSucceeded(event)

--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -12,19 +12,19 @@ import (
 
 type Group struct {
 	gorm.Model
-	GroupID		string		`gorm:"unique;not null" json:"group_id"`
-	XData		string		`gorm:"type:text" json:"xdata"`
-	Data		GroupData	`gorm:"type:jsonb" json:"data"`
-	Systems		[]System	`gorm:"foreignkey:GID"`
+	GroupID string    `gorm:"unique;not null" json:"group_id"`
+	XData   string    `gorm:"type:text" json:"xdata"`
+	Data    GroupData `gorm:"type:jsonb" json:"data"`
+	Systems []System  `gorm:"foreignkey:GID"`
 }
 
 type SystemSummary struct {
-	ID        	uint    	`json:"id"`
-	GID        	uint		`json:"-"`
-	ClientName	string		`json:"client_name"`
-	ClientID	string  	`json:"client_id"`
-	IPs       	[]string	`json:"ips,omitempty"`
-	UpdatedAt 	time.Time	`json:"updated_at"`
+	ID         uint      `json:"id"`
+	GID        uint      `json:"-"`
+	ClientName string    `json:"client_name"`
+	ClientID   string    `json:"client_id"`
+	IPs        []string  `json:"ips,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 func (SystemSummary) TableName() string {
@@ -44,9 +44,9 @@ func (GroupSummary) TableName() string {
 }
 
 type GroupList struct {
-	Count      int        		`json:"count"`
-	ReportedAt time.Time		`json:"reported_at"`
-	Groups     []GroupSummary	`json:"groups"`
+	Count      int            `json:"count"`
+	ReportedAt time.Time      `json:"reported_at"`
+	Groups     []GroupSummary `json:"groups"`
 }
 
 func CreateGroup(gd GroupData, trackingID string) (Group, error) {
@@ -264,8 +264,8 @@ func (gd *GroupData) Scan(value interface{}) error {
 }
 
 type Resource struct {
-	ID     string   `json:"id"`
-	Name   string   `json:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 	// Example: ["bcda-api"]
 	Scopes []string `json:"scopes"`
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -416,15 +416,5 @@ func revokeToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func jsonError(w http.ResponseWriter, errorStatus int, description string) {
-	e := ssas.ErrorResponse{Error: http.StatusText(errorStatus), ErrorDescription: description}
-	body, err := json.Marshal(e)
-	if err != nil {
-		http.Error(w, "", http.StatusInternalServerError)
-	}
-	ssas.Logger.Printf("%s; %s", description, http.StatusText(errorStatus))
-	w.WriteHeader(errorStatus)
-	_, err = w.Write([]byte(body))
-	if err != nil {
-		http.Error(w, "", http.StatusInternalServerError)
-	}
+	service.JsonError(w, errorStatus, http.StatusText(errorStatus), description)
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -416,11 +416,15 @@ func revokeToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func jsonError(w http.ResponseWriter, errorStatus int, description string) {
+	e := ssas.ErrorResponse{Error: http.StatusText(errorStatus), ErrorDescription: description}
+	body, err := json.Marshal(e)
+	if err != nil {
+		http.Error(w, "", http.StatusInternalServerError)
+	}
 	ssas.Logger.Printf("%s; %s", description, http.StatusText(errorStatus))
 	w.WriteHeader(errorStatus)
-	body := []byte(fmt.Sprintf(`{"error":"%s","error_description":"%s"}`, http.StatusText(errorStatus), description))
-	_, err := w.Write(body)
+	_, err = w.Write([]byte(body))
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		http.Error(w, "", http.StatusInternalServerError)
 	}
 }

--- a/ssas/service/admin/api.go
+++ b/ssas/service/admin/api.go
@@ -307,7 +307,8 @@ func resetCredentials(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write(credsJSON)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "internal error")
-	}}
+	}
+}
 
 /*
 	swagger:route GET /system/{systemId}/key system getPublicKey

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -563,7 +563,6 @@ func (s *APITestSuite) TestDeactivateSystemCredentials() {
 }
 
 func (s *APITestSuite) TestJsonError() {
-	// JSON output is valid for simple strings
 	w := httptest.NewRecorder()
 	jsonError(w, http.StatusUnauthorized, "unauthorized")
 	resp := w.Result()
@@ -571,15 +570,6 @@ func (s *APITestSuite) TestJsonError() {
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), json.Valid(body))
 	assert.Equal(s.T(), `{"error":"Unauthorized","error_description":"unauthorized"}`, string(body))
-
-	// JSON output is valid for strings that need to be escaped
-	w = httptest.NewRecorder()
-	jsonError(w, http.StatusInternalServerError, `oh no, there's a database problem (and a backslash \)!: pq: duplicate key value violates unique constraint "groups_group_id_deleted_at_key"`)
-	resp = w.Result()
-	body, err = ioutil.ReadAll(resp.Body)
-	assert.NoError(s.T(), err)
-	assert.True(s.T(), json.Valid(body))
-	assert.Equal(s.T(), `{"error":"Internal Server Error","error_description":"oh no, there's a database problem (and a backslash \\)!: pq: duplicate key value violates unique constraint \"groups_group_id_deleted_at_key\""}`, string(body))
 }
 
 func TestAPITestSuite(t *testing.T) {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -139,8 +139,10 @@ func (s *APITestSuite) TestListGroups() {
 	found2 := false
 	for _, g := range groupList.Groups {
 		switch g.GroupID {
-		case g1ID: found1 = true
-		case g2ID: found2 = true
+		case g1ID:
+			found1 = true
+		case g2ID:
+			found2 = true
 		default: //NOOP
 		}
 	}
@@ -175,7 +177,6 @@ func (s *APITestSuite) TestUpdateGroup() {
 	err = ssas.CleanDatabase(g)
 	assert.Nil(s.T(), err)
 }
-
 
 func (s *APITestSuite) TestUpdateGroupBadGroupID() {
 	gid := ssas.RandomBase64(16)

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -559,6 +560,26 @@ func (s *APITestSuite) TestDeactivateSystemCredentials() {
 	assert.Equal(s.T(), http.StatusOK, rr.Result().StatusCode)
 
 	_ = ssas.CleanDatabase(group)
+}
+
+func (s *APITestSuite) TestJsonError() {
+	// JSON output is valid for simple strings
+	w := httptest.NewRecorder()
+	jsonError(w, http.StatusUnauthorized, "unauthorized")
+	resp := w.Result()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), json.Valid(body))
+	assert.Equal(s.T(), `{"error":"Unauthorized","error_description":"unauthorized"}`, string(body))
+
+	// JSON output is valid for strings that need to be escaped
+	w = httptest.NewRecorder()
+	jsonError(w, http.StatusInternalServerError, `oh no, there's a database problem (and a backslash \)!: pq: duplicate key value violates unique constraint "groups_group_id_deleted_at_key"`)
+	resp = w.Result()
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), json.Valid(body))
+	assert.Equal(s.T(), `{"error":"Internal Server Error","error_description":"oh no, there's a database problem (and a backslash \\)!: pq: duplicate key value violates unique constraint \"groups_group_id_deleted_at_key\""}`, string(body))
 }
 
 func TestAPITestSuite(t *testing.T) {

--- a/ssas/service/api_common.go
+++ b/ssas/service/api_common.go
@@ -14,9 +14,9 @@ func JsonError(w http.ResponseWriter, errorStatus int, errorText string, descrip
 	if err != nil {
 		http.Error(w, fallbackMessage, http.StatusInternalServerError)
 	}
-	ssas.Logger.Printf("%s; %s", description, errorText)
+	ssas.Logger.Printf("%s; %s", description, errorText) // TODO: log information about the request
 	w.WriteHeader(errorStatus)
-	_, err = w.Write([]byte(body))
+	_, err = w.Write(body)
 	if err != nil {
 		http.Error(w, fallbackMessage, http.StatusInternalServerError)
 	}

--- a/ssas/service/api_common.go
+++ b/ssas/service/api_common.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"net/http"
+)
+
+func JsonError(w http.ResponseWriter, errorStatus int, errorText string, description string) {
+	fallbackMessage := fmt.Sprintf(`{"error": "%s", "error_description": "%s"}`, http.StatusText(http.StatusInternalServerError), http.StatusText(http.StatusInternalServerError))
+	e := ssas.ErrorResponse{Error: errorText, ErrorDescription: description}
+	body, err := json.Marshal(e)
+	if err != nil {
+		http.Error(w, fallbackMessage, http.StatusInternalServerError)
+	}
+	ssas.Logger.Printf("%s; %s", description, errorText)
+	w.WriteHeader(errorStatus)
+	_, err = w.Write([]byte(body))
+	if err != nil {
+		http.Error(w, fallbackMessage, http.StatusInternalServerError)
+	}
+}

--- a/ssas/service/api_common_test.go
+++ b/ssas/service/api_common_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"encoding/json"
+	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type APICommonTestSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func (s *APICommonTestSuite) SetupSuite() {
+	ssas.InitializeSystemModels()
+	s.db = ssas.GetGORMDbConnection()
+}
+
+func (s *APICommonTestSuite) TearDownSuite() {
+	ssas.Close(s.db)
+}
+
+func (s *APICommonTestSuite) TestJsonError() {
+	// JSON output is valid for simple strings
+	w := httptest.NewRecorder()
+	JsonError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "unauthorized")
+	resp := w.Result()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), json.Valid(body))
+	assert.Equal(s.T(), `{"error":"Unauthorized","error_description":"unauthorized"}`, string(body))
+
+	// JSON output is valid for strings that need to be escaped
+	w = httptest.NewRecorder()
+	JsonError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), `oh no, there's a database problem (and a backslash \)!: pq: duplicate key value violates unique constraint "groups_group_id_deleted_at_key"`)
+	resp = w.Result()
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), json.Valid(body))
+	assert.Equal(s.T(), `{"error":"Internal Server Error","error_description":"oh no, there's a database problem (and a backslash \\)!: pq: duplicate key value violates unique constraint \"groups_group_id_deleted_at_key\""}`, string(body))
+}
+
+func TestAPICommonTestSuite(t *testing.T) {
+	suite.Run(t, new(APICommonTestSuite))
+}

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -31,11 +31,11 @@ type JWKS struct {
 }
 
 type RegistrationRequest struct {
-	ClientID    string `json:"client_id"`
-	ClientName  string `json:"client_name"`
-	Scope       string `json:"scope,omitempty"`
-	JSONWebKeys JWKS   `json:"jwks"`
-	IPs		  []string `json:"ips"`
+	ClientID    string   `json:"client_id"`
+	ClientName  string   `json:"client_name"`
+	Scope       string   `json:"scope,omitempty"`
+	JSONWebKeys JWKS     `json:"jwks"`
+	IPs         []string `json:"ips"`
 }
 
 type ResetRequest struct {
@@ -55,16 +55,16 @@ type PasswordRequest struct {
 }
 
 type SystemResponse struct {
-	ClientID		string `json:"client_id"`
-	ClientSecret	string `json:"client_secret"`
-	ExpiresAt		int64  `json:"client_secret_expires_at"`
-	ClientName		string `json:"client_name"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	ExpiresAt    int64  `json:"client_secret_expires_at"`
+	ClientName   string `json:"client_name"`
 }
 
 type VerifyMFAResponse struct {
-	FactorResult    	string `json:"factor_result"`
-	RegistrationToken   string `json:"registration_token,omitempty"`
-	AvailableGroups		string `json:"available_groups,omitempty"`
+	FactorResult      string `json:"factor_result"`
+	RegistrationToken string `json:"registration_token,omitempty"`
+	AvailableGroups   string `json:"available_groups,omitempty"`
 }
 
 /*
@@ -270,9 +270,9 @@ func VerifyMultifactorResponse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := VerifyMFAResponse{
-		FactorResult: "success",
+		FactorResult:      "success",
 		RegistrationToken: ts,
-		AvailableGroups: string(gIdsBytes),
+		AvailableGroups:   string(gIdsBytes),
 	}
 	body, err = json.Marshal(response)
 	if err != nil {
@@ -341,10 +341,10 @@ func ResetSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := SystemResponse{
-		ClientID: credentials.ClientID,
+		ClientID:     credentials.ClientID,
 		ClientSecret: credentials.ClientSecret,
-		ExpiresAt: credentials.ExpiresAt.Unix(),
-		ClientName: credentials.ClientName,
+		ExpiresAt:    credentials.ExpiresAt.Unix(),
+		ClientName:   credentials.ClientName,
 	}
 	body, err := json.Marshal(response)
 	if err != nil {
@@ -429,10 +429,10 @@ func RegisterSystem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := SystemResponse{
-		ClientID: credentials.ClientID,
+		ClientID:     credentials.ClientID,
 		ClientSecret: credentials.ClientSecret,
-		ExpiresAt: credentials.ExpiresAt.Unix(),
-		ClientName: credentials.ClientName,
+		ExpiresAt:    credentials.ExpiresAt.Unix(),
+		ClientName:   credentials.ClientName,
 	}
 	body, err := json.Marshal(response)
 	if err != nil {

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -416,13 +416,7 @@ func readRegData(r *http.Request) (data ssas.AuthRegData, err error) {
 }
 
 func jsonError(w http.ResponseWriter, error string, description string) {
-	ssas.Logger.Printf("%s; %s", description, error)
-	w.WriteHeader(http.StatusBadRequest)
-	body := []byte(fmt.Sprintf(`{"error":"%s","error_description":"%s"}`, error, description))
-	_, err := w.Write(body)
-	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-	}
+	service.JsonError(w, http.StatusBadRequest, error, description)
 }
 
 func setHeaders(w http.ResponseWriter) {

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -84,15 +84,42 @@ func (s *APITestSuite) TestAuthRegisterSuccess() {
 	http.HandlerFunc(RegisterSystem).ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusCreated, s.rr.Code)
 
-	j := map[string]string{}
-	err = json.Unmarshal(s.rr.Body.Bytes(), &j)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "my_client_name", j["client_name"])
+	var sys SystemResponse
+	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
+	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.Equal(s.T(), "my_client_name", sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
 }
 
+func (s *APITestSuite) TestAuthRegisterJSON() {
+	groupID := "T12123"
+	group := ssas.Group{GroupID: groupID}
+	err := s.db.Create(&group).Error
+	if err != nil {
+		s.FailNow(err.Error())
+	}
+
+	regBody := strings.NewReader(fmt.Sprintf(`{"client_id":"my_client_id","client_name":"My\\Name\\Has\"Escaped Chars\"","scope":"%s","jwks":{"keys":[{"e":"AAEAAQ","n":"ok6rvXu95337IxsDXrKzlIqw_I_zPDG8JyEw2CTOtNMoDi1QzpXQVMGj2snNEmvNYaCTmFf51I-EDgeFLLexr40jzBXlg72quV4aw4yiNuxkigW0gMA92OmaT2jMRIdDZM8mVokoxyPfLub2YnXHFq0XuUUgkX_TlutVhgGbyPN0M12teYZtMYo2AUzIRggONhHvnibHP0CPWDjCwSfp3On1Recn4DPxbn3DuGslF2myalmCtkujNcrhHLhwYPP-yZFb8e0XSNTcQvXaQxAqmnWH6NXcOtaeWMQe43PNTAyNinhndgI8ozG3Hz-1NzHssDH_yk6UYFSszhDbWAzyqw","kty":"RSA"}]}}`,
+		ssas.DefaultScope))
+
+	req, err := http.NewRequest("GET", "/auth/register", regBody)
+	assert.Nil(s.T(), err)
+
+	req = addRegDataContext(req, "T12123", []string{"T12123"})
+	http.HandlerFunc(RegisterSystem).ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusCreated, s.rr.Code)
+
+	assert.True(s.T(), json.Valid(s.rr.Body.Bytes()))
+	var sys SystemResponse
+	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
+	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.Equal(s.T(), `My\Name\Has"Escaped Chars"`, sys.ClientName)
+
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
 
 func (s *APITestSuite) TestAuthRegisterNoKey() {
 	groupID := "T12123"
@@ -112,10 +139,10 @@ func (s *APITestSuite) TestAuthRegisterNoKey() {
 	http.HandlerFunc(RegisterSystem).ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusCreated, s.rr.Code)
 
-	j := map[string]string{}
-	err = json.Unmarshal(s.rr.Body.Bytes(), &j)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "my_client_name", j["client_name"])
+	var sys SystemResponse
+	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
+	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.Equal(s.T(), "my_client_name", sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
@@ -196,10 +223,51 @@ func (s *APITestSuite) TestResetSecretSuccess() {
 	}
 	hash := ssas.Hash(newSecret.Hash)
 
-	j := map[string]string{}
-	err = json.Unmarshal(s.rr.Body.Bytes(), &j)
+	var sys SystemResponse
+	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
+	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.True(s.T(), hash.IsHashOf(sys.ClientSecret))
+
+	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
-	assert.True(s.T(), hash.IsHashOf(j["client_secret"]))
+}
+
+func (s *APITestSuite) TestResetSecretJSON() {
+	groupID := "T23234"
+	group := ssas.Group{GroupID: groupID}
+	if err := s.db.Create(&group).Error; err != nil {
+		s.FailNow("unable to create group: " + err.Error())
+	}
+	system := ssas.System{GID: group.ID, GroupID: group.GroupID, ClientID: "abcd1234", ClientName: `This\Name "has escaped chars`}
+	if err := s.db.Create(&system).Error; err != nil {
+		s.FailNow("unable to create system: " + err.Error())
+	}
+
+	hashedSecret := ssas.Hash("no_secret_at_all")
+	secret := ssas.Secret{Hash: hashedSecret.String(), SystemID: system.ID}
+	if err := s.db.Create(&secret).Error; err != nil {
+		s.FailNow("unable to create secret: " + err.Error())
+	}
+
+	body := strings.NewReader(`{"client_id":"abcd1234"}`)
+	req, err := http.NewRequest("PUT", "/reset", body)
+	assert.Nil(s.T(), err)
+
+	req = addRegDataContext(req, groupID, []string{groupID})
+	http.HandlerFunc(ResetSecret).ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+
+	newSecret := ssas.Secret{}
+	if err = s.db.Where("system_id = ?", system.ID).First(&newSecret).Error; err != nil {
+		s.FailNow("unable to find secret: " + err.Error())
+	}
+	hash := ssas.Hash(newSecret.Hash)
+
+	var sys SystemResponse
+	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
+	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.True(s.T(), hash.IsHashOf(sys.ClientSecret))
+	assert.Equal(s.T(), `This\Name "has escaped chars`, sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -392,7 +392,6 @@ func (s *APITestSuite) TestSaveTokenTime() {
 	assert.Nil(s.T(), err)
 }
 
-
 func (s *APITestSuite) TestJsonError() {
 	w := httptest.NewRecorder()
 	jsonError(w, http.StatusText(http.StatusUnauthorized), "unauthorized")

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -86,7 +86,7 @@ func (s *APITestSuite) TestAuthRegisterSuccess() {
 
 	var sys SystemResponse
 	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
-	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.NoError(s.T(), err, s.rr.Body.String())
 	assert.Equal(s.T(), "my_client_name", sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
@@ -114,7 +114,7 @@ func (s *APITestSuite) TestAuthRegisterJSON() {
 	assert.True(s.T(), json.Valid(s.rr.Body.Bytes()))
 	var sys SystemResponse
 	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
-	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.NoError(s.T(), err, s.rr.Body.String())
 	assert.Equal(s.T(), `My\Name\Has"Escaped Chars"`, sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
@@ -141,7 +141,7 @@ func (s *APITestSuite) TestAuthRegisterNoKey() {
 
 	var sys SystemResponse
 	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
-	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.NoError(s.T(), err, s.rr.Body.String())
 	assert.Equal(s.T(), "my_client_name", sys.ClientName)
 
 	err = ssas.CleanDatabase(group)
@@ -225,7 +225,7 @@ func (s *APITestSuite) TestResetSecretSuccess() {
 
 	var sys SystemResponse
 	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
-	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.NoError(s.T(), err, s.rr.Body.String())
 	assert.True(s.T(), hash.IsHashOf(sys.ClientSecret))
 
 	err = ssas.CleanDatabase(group)
@@ -265,7 +265,7 @@ func (s *APITestSuite) TestResetSecretJSON() {
 
 	var sys SystemResponse
 	err = json.Unmarshal(s.rr.Body.Bytes(), &sys)
-	assert.NoError(s.T(), err, string(s.rr.Body.Bytes()))
+	assert.NoError(s.T(), err, s.rr.Body.String())
 	assert.True(s.T(), hash.IsHashOf(sys.ClientSecret))
 	assert.Equal(s.T(), `This\Name "has escaped chars`, sys.ClientName)
 

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -321,6 +322,17 @@ func (s *APITestSuite) TestSaveTokenTime() {
 
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
+}
+
+
+func (s *APITestSuite) TestJsonError() {
+	w := httptest.NewRecorder()
+	jsonError(w, http.StatusText(http.StatusUnauthorized), "unauthorized")
+	resp := w.Result()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), json.Valid(body))
+	assert.Equal(s.T(), `{"error":"Unauthorized","error_description":"unauthorized"}`, string(body))
 }
 
 func TestAPITestSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-2664](https://jira.cms.gov/browse/BCDA-2664)
During testing, the ACO-MS team found an example SSAS response that was not valid JSON. This PR fixes that and other instances where errors or user input might need to be escaped.

### Proposed Changes
- Refactor `jsonError()` methods in `public` and `admin` servers to share JSON-marshaling code
- Add tests that assert proper JSON escaping 
- Suppress full error details from `admin` endpoints

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

No new information is presented, and very little is changed in the way of format.  These changes add certainty that the API's output is JSON-compliant.

### Acceptance Validation
![Screen Shot 2020-02-25 at 8 27 18 PM](https://user-images.githubusercontent.com/2533561/75302915-42fe4280-580d-11ea-8073-163b1327ab15.png)

### Feedback Requested
- All feedback welcome