### PR TITLE
Update SSAS Credential Expiration Env Var Name

### DIFF
--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -40,7 +40,7 @@ func getEnvVars() {
 		panic("SSAS_DEFAULT_SYSTEM_SCOPE environment value must be set")
 	}
 
-	expirationDays := cfg.GetEnvInt("SSAS_CREDENTIAL_EXPIRATION_DAYS", 90)
+	expirationDays := cfg.GetEnvInt("SSAS_CRED_EXPIRATION_DAYS", 90)
 	CredentialExpiration = time.Duration(expirationDays*24) * time.Hour
 }
 


### PR DESCRIPTION
We currently have environment variables for `SSAS_CRED_EXPIRATION_DAYS` and `SSAS_CREDENTIAL_EXPIRATION_DAYS`.  We should combine these and just use one environment variable name.

### Change Details

- Renamed `SSAS_CREDENTIAL_EXPIRATION_DAYS` to be `SSAS_CRED_EXPIRATION_DAYS`

### Security Implications

No PHI/PII is affected by this name change.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications


### Acceptance Validation

In both cases, the environment variable is not defined in any environment so the default is being used.  Therefore, no real affect is had on any environment aside from alignment.

### Feedback Requested

Please review.
