### PR TITLE
Add gofmt test to pre-commit git hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Some variables below have a note indicating their name should be changed. These 
 | BCDA_TLS_CERT        | Depends  | X |   | The cert used when the SSAS service is running in secure mode. When setting vars for AWS envs, you must include a var for the cert material. This var should be renamed to SSAS_TLS_CERT. |
 | BCDA_TLS_KEY         | Depends  | X |   | The private key used when the SSAS service is running in secure mode. When setting vars for AWS envs, you must include a var for the key material. This var should be renamed to SSAS_TLS_KEY. |
 
+# Development Setup
+
+To avoid committing and pushing unencrypted secret files, use the included `scripts/pre-commit` git pre-commit hook by running the following script from the repository root directory:
+```
+cp ops/pre-commit .git/hooks
+```
+
 # Build
 
 Build all the code and containers with `make docker-bootstrap`. Alternatively, `docker-compose up ssas` will build and run the SSAS by itself. Note that SSAS needs the db container to be running as well.

--- a/ops/pre-commit
+++ b/ops/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# A pre-commit hook which checks if any files need to be gofmt'd
+
+# the following is based on: 
+# https://github.com/golang/go/blob/release-branch.go1.1/misc/git/pre-commit
+
+tmpfile=$(mktemp)
+git diff --cached --name-only --diff-filter=ACM > $tmpfile
+
+# Are there any added, copied, or modified .go files that are staged for commit?
+gofiles=$(grep '.go$' < "$tmpfile")
+[ -z "$gofiles" ] && exit 0
+
+# Check if they need to be formatted
+unformatted=$(gofmt -l "$gofiles")
+[ -z "$unformatted" ] && exit 0
+
+# Some files are not gofmt'd. Print message and fail.
+echo >&2 "Go files must be formatted with gofmt. Please run:"
+for fn in $unformatted; do
+    echo >&2 "  gofmt -w $PWD/$fn"
+done
+
+exit 1


### PR DESCRIPTION
### Fixes [BCDA-2778](https://jira.cms.gov/browse/BCDA-2778)

This branch adds a script to the pre-commit git hook that checks if any staged go files that are added, copied, or modified need to be formatted with gofmt.

This is a companion PR to https://github.com/CMSgov/bcda-app/pull/473

### Proposed Changes

* Adding some logic to ops/pre-commit based on this and making the script executable.
* Updating `README.md` with instructions to install this pre-commit hook

### Change Details

Using `gofmt` logic from pre-commit hook in `bcda-app`

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

### Acceptance Validation
This does not need to be tested in `dev` as it is only for local dev environment.
### Feedback Requested

All feedback is welcome.