### PR TITLE
Update TLS Config to explicitly specify MinVersion

### DIFF
--- a/ssas/okta/okta.go
+++ b/ssas/okta/okta.go
@@ -114,7 +114,7 @@ func NewTestClient(fn RoundTripFunc) *http.Client {
 func makeDialer(fingerprint []byte) Dialer {
 	return func(network, addr string) (net.Conn, error) {
 		var errMessage string
-		c, err := tls.Dial(network, addr, &tls.Config{})
+		c, err := tls.Dial(network, addr, &tls.Config{MinVersion: tls.VersionTLS12})
 		if err != nil {
 			return c, err
 		}


### PR DESCRIPTION
### Fixes Issue Uncovered by GoSec

A new linting rule was added to `gosec` [today](https://github.com/securego/gosec/pull/493/files), and our software is not compliant with the new rule.  The new rule aims to be more strict at analyzing the Min/Max TLS versions supported in the software.

### Change Details

Because our Akamai configuration only support TLSv1.2 and above, we can explicitly specify a `MinVersion` of TLSv1.2 in our Go code.

From Akamai configuration:

<img width="950" alt="Screen Shot 2020-06-26 at 9 57 55 AM" src="https://user-images.githubusercontent.com/37818548/85865274-a2586900-b793-11ea-985b-603354ddb3ff.png">

### Security Implications

In this PR, we are aligning the software configuration defining the minimum TLS version to our infrastructure configuration.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

[Deployed](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/1597/parameters/) to `dev` and passed all [smoke tests](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Test%20-%20Integration%20Smoke/2053/).

### Feedback Requested

Please review.
