### PR TITLE
BCDA-3099 - Encode iter count into hash value

### DIFF
--- a/ssas/hash_test.go
+++ b/ssas/hash_test.go
@@ -43,7 +43,8 @@ func (s *HashTestSuite) TestHashEmpty() {
 
 func (s *HashTestSuite) TestHashInvalid() {
 	for _, val := range []string{"INVALID_NUMBER_OF_SEGMENTS:d3H4fX/uEk1jOW2gYrFezyuJoSv4ay2x3gH5C25KpWM=:kVqFm1he5S4R1/10oIkVNFot40VB3wTa+DXTp4TrwvyXHkQO7Dxjjo/OqwemiYP8p3UQ8r/HkmTQrSS99UXzaQ==",
-		"TOO_FEW_PARTS"} {
+		"TOO_FEW_PARTS",
+		"A:B:NaN"} {
 		hash := Hash(val)
 		assert.False(s.T(), hash.IsHashOf("96c5a0cd-b284-47ac-be6e-f33b14dc4697"))
 	}

--- a/ssas/hash_test.go
+++ b/ssas/hash_test.go
@@ -1,10 +1,13 @@
 package ssas
 
 import (
+	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type HashTestSuite struct {
@@ -39,8 +42,26 @@ func (s *HashTestSuite) TestHashEmpty() {
 }
 
 func (s *HashTestSuite) TestHashInvalid() {
-	hash := Hash("INVALID_NUMBER_OF_SEGMENTS:d3H4fX/uEk1jOW2gYrFezyuJoSv4ay2x3gH5C25KpWM=:kVqFm1he5S4R1/10oIkVNFot40VB3wTa+DXTp4TrwvyXHkQO7Dxjjo/OqwemiYP8p3UQ8r/HkmTQrSS99UXzaQ==")
-	assert.False(s.T(), hash.IsHashOf("96c5a0cd-b284-47ac-be6e-f33b14dc4697"))
+	for _, val := range []string{"INVALID_NUMBER_OF_SEGMENTS:d3H4fX/uEk1jOW2gYrFezyuJoSv4ay2x3gH5C25KpWM=:kVqFm1he5S4R1/10oIkVNFot40VB3wTa+DXTp4TrwvyXHkQO7Dxjjo/OqwemiYP8p3UQ8r/HkmTQrSS99UXzaQ==",
+		"TOO_FEW_PARTS"} {
+		hash := Hash(val)
+		assert.False(s.T(), hash.IsHashOf("96c5a0cd-b284-47ac-be6e-f33b14dc4697"))
+	}
+}
+
+func (s *HashTestSuite) TestHashWithIter() {
+	val := uuid.New()
+	h, err := NewHash(val)
+	s.NoError(err)
+	// Verify that we've encoded the iter count into the hash value
+	parts := strings.Split(string(h), ":")
+	s.Equal(3, len(parts))
+
+	// Create hash value without the iter count
+	h1 := Hash(fmt.Sprintf("%s:%s", parts[0], parts[1]))
+
+	s.True(h.IsHashOf(val))
+	s.True(h1.IsHashOf(val))
 }
 
 func TestHashTestSuite(t *testing.T) {


### PR DESCRIPTION
### Related to [BCDA-3099](https://jira.cms.gov/browse/BCDA-3099)

With [BCDA-3099](https://jira.cms.gov/browse/BCDA-3099), we discovered that our hash computation time is between 100 and 200ms. We want the computation time to take ~1s.

To increase the computation time, we need to increase the iteration count. If we increase the iteration count by increasing `SSAS_HASH_ITERATIONS`, we would invalidate all of current hashes.  To avoid this, we want to encode the iteration count into our hash payload.

Encoding the iteration count is based off of `BKDF2-params` found in [RFC-2898](https://www.ietf.org/rfc/rfc2898.txt)

### Change Details

1. When generating a new hash, we will encode the iteration count as the third parameter.
2. When verifying the hash, we will default to `SSSAS_HASH_ITERATIONS` if we do not have a iteration count inside the hash payload.

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [x] new data stored or transmitted

We are storing the iteration count in the hash payload. This is based on [RFC-2898](https://www.ietf.org/rfc/rfc2898.txt)

- [ ] security checklist is completed for this change

Security Checklist created: https://confluence.cms.gov/display/BCDA/20-10-28%3A+Encoding+Hash+Iteration+in+Payload+Security+Checklist

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation
1. Added test to verify backwards compatibility (i.e. no iteration encoded  in the payload).
2. Deployed to dev and validated that iteration count is used when supplied.
3. SSAS postman tests verified that newly created secrets have the iteration count payload present.
