### PR TITLE
BCDA-3847 - Resolve issues found in tokenblacklist impl

### DIFF
--- a/ssas/service/tokenblacklist.go
+++ b/ssas/service/tokenblacklist.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	TokenBlacklist Blacklist
+	TokenBlacklist *Blacklist
 	// This default cache timeout value should never be used, since individual cache elements have their own timeouts
 	defaultCacheTimeout  = 24 * time.Hour
 	cacheCleanupInterval time.Duration
@@ -32,7 +32,7 @@ func init() {
 
 // This function should only be called by main
 func StartBlacklist() {
-	NewBlacklist(defaultCacheTimeout, cacheCleanupInterval)
+	TokenBlacklist = NewBlacklist(defaultCacheTimeout, cacheCleanupInterval)
 }
 
 //	NewBlacklist allows for easy Blacklist{} creation and manipulation during testing, and, outside a test suite,
@@ -59,7 +59,6 @@ func NewBlacklist(cacheTimeout time.Duration, cleanupInterval time.Duration) *Bl
 
 	cacheRefreshTicker, cancelFunc = bl.startCacheRefreshTicker(cacheRefreshFreq)
 
-	TokenBlacklist = bl
 	return &bl
 }
 


### PR DESCRIPTION
### Discovered when working on [BCDA-3847](https://jira.cms.gov/browse/BCDA-3847)

While working on the extension of the blacklist, we discovered some possible bugs in tokenblacklist.go.

1. Race condition when the token cache is rebuilt. We can encounter false negatives (token should be blacklisted, but we consider it to not be) when we are rebuilding the cache from the database.
2. Resource leak when stopping the cache refresh ticker. We never finish the associated goroutine.
3. We were computing a negative cache lifetime when loading token entries from the database. This does not have much real world impact since the cache is routine rebuilt.

### Change Details

1. Use a RWMutex to prevent reads from occurring when we are rebuilding the cache.
2. Return a CancelFunc to allow us to terminate the goroutine that was created when starting the cache refresh ticker.
3. Use `time.Until()` to compute the remaining time the token should exist in the cache.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

CI Passes
