### PR TITLE
Fix bcda-ssas-app build trigger

### DIFF
--- a/ops/Jenkinsfile.build_trigger
+++ b/ops/Jenkinsfile.build_trigger
@@ -51,7 +51,7 @@ pipeline {
      steps {
         build job: 'BCDA - Build and Package',
         // Since this is being triggered by a code delivery to SSAS repo, it should always be built with BCDA master
-        parameters: [string(string(name: 'SSAS_GIT_VERSION', value: "${env.BRANCH_NAME}"), name: 'BCDA_GIT_VERSION', value: "master"),  string(name: 'DEPLOY', value: "${DEPLOY}")],
+        parameters: [string(name: 'SSAS_GIT_VERSION', value: "${env.BRANCH_NAME}"), string(name: 'DEPLOY', value: "${DEPLOY}")], 
         wait: true,
         propagate: true
      }


### PR DESCRIPTION
The `bcda-ssas-app` [build trigger](https://bcda-ci.adhocteam.us/job/SSAS%20-%20Build%20and%20Package%20-%20Trigger/job/master/) was failing silently with the following error:
```
java.lang.IllegalArgumentException: 
Expected named arguments but got 
[{name=BCDA_GIT_VERSION, value=master}, @string(name=SSAS_GIT_VERSION,value=master)]
```

### Change Details

-  FIxed the `bcda-ssas-app` build trigger to match that of the functional `bcda-app` build trigger found [here](https://github.com/CMSgov/bcda-app/blob/master/ops/Jenkinsfile.build_trigger#L54).  

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

 N/A

### Feedback Requested

Please review.
