### PR TITLE
Sl/bcda 3921 create cli to identify aco

### DIFF
--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -364,7 +364,7 @@ func showXData(clientID, auth string) error {
 	if auth != "" {
 		c, err := base64.StdEncoding.DecodeString(auth)
 		if err != nil {
-			return errors.New("unable to decode the auth hash: " + err.Error())
+			return fmt.Errorf("unable to decode the auth hash: %w", err)
 		}
 
 		cs := string(c)
@@ -379,12 +379,12 @@ func showXData(clientID, auth string) error {
 
 	system, err := ssas.GetSystemByClientID(clientID)
 	if err != nil {
-		return errors.New("invalid client id: " + err.Error())
+		return fmt.Errorf("invalid client id: %w", err)
 	}
 
 	group, err := ssas.GetGroupByGroupID(system.GroupID)
 	if err != nil {
-		return errors.New("unable to find group with id " + system.GroupID + ": " + err.Error())
+		return fmt.Errorf("unable to find group with id %v: %w", system.GroupID, err)
 	}
 
 	fmt.Fprintln(output, group.XData)

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -81,7 +81,7 @@ func init() {
 	const usageListExpCreds = "list credentials about to expire or timeout due to inactivity"
 	flag.BoolVar(&doListExpCreds, "list-exp-creds", false, usageListExpCreds)
 
-	const usageShowXData = "display ACOs group xdata"
+	const usageShowXData = "display group xdata"
 	flag.BoolVar(&doShowXData, "show-xdata", false, usageShowXData)
 	flag.StringVar(&auth, "auth", "", "an auth header containing the hashed client id")
 
@@ -362,12 +362,7 @@ func cliTrackingID() string {
 func showXData(clientID, auth string) error {
 	// The auth header decoding logic was pulled from Go's requuest.go#parseBasicAuth func
 	if auth != "" {
-		const prefix = "Basic "
-		// Check that the auth provided that has more than just the `Basic` prefix
-		if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
-			return errors.New("must provide a valid auth hash")
-		}
-		c, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+		c, err := base64.StdEncoding.DecodeString(auth)
 		if err != nil {
 			return errors.New("unable to decode the auth hash: " + err.Error())
 		}

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -35,7 +35,10 @@ func (s *MainTestSuite) TestResetSecret() {
 func (s *MainTestSuite) TestShowXDataWithClientID() {
 	creds, _ := ssas.CreateACOData(s.T(), s.db)
 
-	output := captureOutput(func() { showXData(creds.ClientID, "") })
+	output := captureOutput(func() {
+		err := showXData(creds.ClientID, "")
+		assert.Nil(s.T(), err)
+	})
 	assert.Equal(s.T(), "fake x_data\n", output)
 }
 
@@ -45,7 +48,10 @@ func (s *MainTestSuite) TestShowXDataWithAuth() {
 	// Build encoded api key to mimic auth header
 	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(creds.ClientID+":"+creds.ClientSecret))
 
-	output := captureOutput(func() { showXData("", auth) })
+	output := captureOutput(func() {
+		err := showXData("", auth)
+		assert.Nil(s.T(), err)
+	})
 	assert.Equal(s.T(), "fake x_data\n", output)
 }
 

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -33,7 +33,7 @@ func (s *MainTestSuite) TestResetSecret() {
 }
 
 func (s *MainTestSuite) TestShowXDataWithClientID() {
-	creds, _ := ssas.CreateACOData(s.T(), s.db)
+	creds, _ := ssas.CreateTestXData(s.T(), s.db)
 
 	output := captureOutput(func() {
 		err := showXData(creds.ClientID, "")
@@ -43,10 +43,10 @@ func (s *MainTestSuite) TestShowXDataWithClientID() {
 }
 
 func (s *MainTestSuite) TestShowXDataWithAuth() {
-	creds, _ := ssas.CreateACOData(s.T(), s.db)
+	creds, _ := ssas.CreateTestXData(s.T(), s.db)
 
 	// Build encoded api key to mimic auth header
-	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(creds.ClientID+":"+creds.ClientSecret))
+	auth := base64.StdEncoding.EncodeToString([]byte(creds.ClientID + ":" + creds.ClientSecret))
 
 	output := captureOutput(func() {
 		err := showXData("", auth)

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -338,7 +338,7 @@ func (s *APITestSuite) testIntrospectFlaw(flaw service.TokenFlaw, errorText stri
 		signingKeyPath = os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
 	}
 
-	creds, group := ssas.CreateACOData(s.T(), s.db)
+	creds, group := ssas.CreateTestXData(s.T(), s.db)
 
 	system, err := ssas.GetSystemByClientID(creds.ClientID)
 	assert.Nil(s.T(), err)
@@ -387,7 +387,7 @@ func (s *APITestSuite) TestIntrospectFailure() {
 }
 
 func (s *APITestSuite) TestIntrospectSuccess() {
-	creds, group := ssas.CreateACOData(s.T(), s.db)
+	creds, group := ssas.CreateTestXData(s.T(), s.db)
 
 	req := httptest.NewRequest("POST", "/token", nil)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)

--- a/ssas/testutils.go
+++ b/ssas/testutils.go
@@ -117,7 +117,7 @@ func someRandomBytes(n int) ([]byte, error) {
 	return b, nil
 }
 
-func CreateACOData(t *testing.T, db *gorm.DB) (creds Credentials, group Group) {
+func CreateTestXData(t *testing.T, db *gorm.DB) (creds Credentials, group Group) {
 	groupID := RandomHexID()[0:4]
 
 	group = Group{GroupID: groupID, XData: "fake x_data"}

--- a/ssas/testutils.go
+++ b/ssas/testutils.go
@@ -8,6 +8,12 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ResetAdminCreds() (encSecret string, err error) {
@@ -109,4 +115,24 @@ func someRandomBytes(n int) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+func CreateACOData(t *testing.T, db *gorm.DB) (creds Credentials, group Group) {
+	groupID := RandomHexID()[0:4]
+
+	group = Group{GroupID: groupID, XData: "fake x_data"}
+	err := db.Create(&group).Error
+	require.Nil(t, err)
+
+	_, pubKey, err := GenerateTestKeys(2048)
+	require.Nil(t, err)
+	pemString, err := ConvertPublicKeyToPEMString(&pubKey)
+	require.Nil(t, err)
+
+	creds, err = RegisterSystem("Test Client Name", groupID, DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	assert.Nil(t, err)
+	assert.Equal(t, "Test Client Name", creds.ClientName)
+	assert.NotNil(t, creds.ClientSecret)
+
+	return
 }


### PR DESCRIPTION
### Fixes [BCDA-3921](https://jira.cms.gov/browse/BCDA-3921)

Due to an incident it was determined that we needed a way to identify ACO's by either supplying their client_id or their API key.

### Proposed Changes

Create a CLI command that takes in either the client id or the api key and prints out the ACO's xdata field from `Group`. This will supply the ACO's ID.

### Change Details

Just as noted above. The main.go now has a new cli flag `get-xdata` that requires either the `client-id` or the `api-key` flag to be set as well. Either of these identifiers will allow the cli tool to gather the xdata for the ACO and print it to stdout.

Note: If both identifiers are provided, the API key will supersede the client id.
 
### Security Implications

This is slightly difficult for me to answer as I dont know the eco system that well yet. I'm not sure what else this xdata field holds but, regardless, it will dumped to stdout and logged. These logs are most likely accessible somewhere else (ie Splunk?). However, this is all being run behind our firewall so if someone could access to that then running this cli command or retrieving the results are probably the least of our concerns.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [ ] no PHI/PII is affected by this change

### Acceptance Validation

AC has been met. We can now retrieve the ACO id for a given secret.

### Feedback Requested

As always, let me know if there is a more GOmatic way to do things! Also, let me know if I misinterpreted anything with my naming... and should rename something to be more accurate. The words ACO, system, client, etc... are thrown around a lot and I want to make sure I used them accurately.

Also if there are some other tests cases that would be valuable.
