### PR TITLE
BCDA-3917 Determine SSAS_HASH_ITERATIONS value

### DIFF
--- a/ssas/hash.go
+++ b/ssas/hash.go
@@ -26,7 +26,8 @@ var (
 type Hash string
 
 // The time for hash comparison should be about 1s.  Increase hashIter if this is significantly faster in production.
-// Note that changing hashIter or hashKeyLen will result in invalidating existing stored hashes (e.g. credentials).
+// Use the TestHashIterTime test to determine the amount required to reach 1s.
+// Note that changing hashKeyLen will result in invalidating existing stored hashes (e.g. credentials).
 func init() {
 	if os.Getenv("DEBUG") == "true" {
 		hashIter = cfg.GetEnvInt("SSAS_HASH_ITERATIONS", 130000)

--- a/ssas/hash_test.go
+++ b/ssas/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,25 @@ func (s *HashTestSuite) TestHashWithIter() {
 
 	s.True(h.IsHashOf(val))
 	s.True(h1.IsHashOf(val))
+}
+
+func (s *HashTestSuite) TestHashIterTime() {
+	var resultArr [5]int64
+	hashIter = 130000
+	hashKeyLen = 64
+	saltSize = 32
+	for i := 0; i < 5; i++ {
+		start := time.Now()
+
+		val := uuid.New()
+		_, err := NewHash(val)
+		s.NoError(err)
+
+		elapsed := time.Now().Sub(start).Milliseconds()
+		resultArr[i] = elapsed
+		fmt.Println(elapsed)
+	}
+	// Print average of results
 }
 
 func TestHashTestSuite(t *testing.T) {

--- a/ssas/hash_test.go
+++ b/ssas/hash_test.go
@@ -2,6 +2,7 @@ package ssas
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -66,23 +67,33 @@ func (s *HashTestSuite) TestHashWithIter() {
 	s.True(h1.IsHashOf(val))
 }
 
-func (s *HashTestSuite) TestHashIterTime() {
-	var resultArr [5]int64
-	hashIter = 130000
-	hashKeyLen = 64
-	saltSize = 32
-	for i := 0; i < 5; i++ {
+func TestHashIterTime(t *testing.T) {
+	// This test is not intended to run with the remain suite.  Is is solely used to determine the number of hash
+	// iterations needed to reach a 1 second duration. To invoke the test use:
+	// DEBUG=true  go test -v github.com/CMSgov/bcda-ssas-app/ssas -run TestHashIterTime
+
+	// Check for local dev environment
+	if os.Getenv("DEBUG") != "true" {
+		t.SkipNow()
+	}
+
+	var resultTime int64
+	runCount := 5
+	hashIter = 1650000
+	for i := 0; i < runCount; i++ {
 		start := time.Now()
 
 		val := uuid.New()
 		_, err := NewHash(val)
-		s.NoError(err)
+		if err != nil {
+			t.FailNow()
+		}
 
-		elapsed := time.Now().Sub(start).Milliseconds()
-		resultArr[i] = elapsed
-		fmt.Println(elapsed)
+		elapsed := time.Since(start).Milliseconds()
+		resultTime += elapsed
 	}
-	// Print average of results
+
+	fmt.Printf("The average is: %dms\n", (int(resultTime) / runCount))
 }
 
 func TestHashTestSuite(t *testing.T) {

--- a/ssas/hash_test.go
+++ b/ssas/hash_test.go
@@ -72,12 +72,11 @@ func TestHashIterTime(t *testing.T) {
 	// iterations needed to reach a 1 second duration. To invoke the test use:
 	// DEBUG=true  go test -v github.com/CMSgov/bcda-ssas-app/ssas -run TestHashIterTime
 
-	// Check for local dev environment
 	if os.Getenv("DEBUG") != "true" {
 		t.SkipNow()
 	}
 
-	var resultTime int64
+	var totalTime time.Duration
 	runCount := 5
 	hashIter = 1650000
 	for i := 0; i < runCount; i++ {
@@ -89,11 +88,12 @@ func TestHashIterTime(t *testing.T) {
 			t.FailNow()
 		}
 
-		elapsed := time.Since(start).Milliseconds()
-		resultTime += elapsed
+		elapsed := time.Since(start)
+		totalTime += elapsed
 	}
 
-	fmt.Printf("The average is: %dms\n", (int(resultTime) / runCount))
+	avgDur := totalTime / time.Duration(runCount)
+	fmt.Printf("The average is: %s\n", avgDur.String())
 }
 
 func TestHashTestSuite(t *testing.T) {


### PR DESCRIPTION
### Fixes [BCDA-3917](https://jira.cms.gov/browse/BCDA-3917)

We want our hash generation in SSAS to take ~1s.

We had discovered that not all entries in the secrets table have the iteration count encoded. This will prevent us from updating the env var w/o invalidating the credentials associated with those hash entries. 

### Proposed Changes

Create a stand alone test that does not run in CI/CD that allows to test the number of iterations needed to reach 1s.

### Change Details

Added TestHashIterTime test that uses a Skip conditional based on a local / runtime specified environment variable.

### Security Implications

This test itself has no security implications.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

We have determined the hash iteration count that will take ~1s to generate.

### Feedback Requested

Go best practices, different approach to solution.
