### PR TITLE
Updated usql go get command to work with modules.

### DIFF
--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -2,7 +2,7 @@ FROM golang:1.15-buster
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
-RUN go get -u github.com/xo/usql
+RUN GO111MODULE=on go get -u github.com/xo/usql
 RUN go get -u github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -2,7 +2,7 @@ FROM golang:1.15-buster
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
-RUN GO111MODULE=on go get -u github.com/xo/usql
+RUN GO111MODULE=on go get github.com/xo/usql
 RUN go get -u github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \


### PR DESCRIPTION
### Fixes [BCDA-4383](https://jira.cms.gov/browse/BCDA-4383)

SSAS App builds are failing locally and on Github Actions due to the tool usql updating to modules. usql is used during the unit tests and does not affect the operation of the application itself.

### Proposed Changes

Add inline `GO111MODULE=on` for usql

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

App builds locally with `--no-cache` option and builds successfully in Github Actions

### Feedback Requested

Better ways!
