### PR TITLE
BCDA-4354 Alpha and Okta auth providers from bcda-app

### DIFF
--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -190,11 +190,11 @@ func addFixtureData() {
 	}
 	makeSystem(db, "admin", "31e029ef-0e97-47f8-873c-0e8b7e7f99bf",
 		"BCDA API Admin", "bcda-admin",
-		"nbZ5oAnTlzyzeep46bL4qDGGuidXuYxs3xknVWBKjTI=:9s/Tnqvs8M7GN6VjGkLhCgjmS59r6TaVguos8dKV9lGqC1gVG8ywZVEpDMkdwOaj8GoNe4TU3jS+OZsK3kTfEQ==",
+		"ofSsVmNaR6+nq93pGUhzKcLvJlokzE4mKqBxS8kt5Fc=:yt+N0wLzqZsY4Lw0pIEWlySbU7y7P7mNnn8IUjsZR0qis9/X2aKtjAMKlFRcCp+CYDeF/+FrvzuCDqacQwX+hA==:130000",
 	)
 	makeSystem(db, "0c527d2e-2e8a-4808-b11d-0fa06baf8254",
 		"0c527d2e-2e8a-4808-b11d-0fa06baf8254", "ACO Dev", "bcda-api",
-		"h5hF9cm0Wmm+ClnoF0+Dq5JCQFmDVtzAsaquigoYcTk=:mptcWsBLNYFylRT1q95brbfKiaQkUt8oZXml0EMXobghbVVewZeG40EfNqe10u1+RftftEMvzSCB/oG17MRpVA==")
+		"bUtFIoldpvBjK92JoJrZEQCZbjTAI0o5RRJ+krdHMFA=:iKOi8/rskQ+ykmA32f3iVNQ6SWBJbWrC0weq7K6R1LF164zKcmQ8PXa4CMUZ1kd8sBBqvP+ISTYqwDu9C+5dtA==:130000")
 }
 
 func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) {


### PR DESCRIPTION
### Fixes [BCDA-4354](https://jira.cms.gov/browse/BCDA-4354)
### Proposed Changes
To prevent local take from regenerating id and secrets, we would like to change the id and hash in add-fixture end point.  The associated secrets will be encrypted and stored elsewhere.
### Change Details
Change is and secrets in add-fixture end point, which is only used in local testing.
### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
### Acceptance Validation
Change only include what is mentioned in this ticket, and nothing else is changed.
CI passes.
### Feedback Requested
None at this time.
