### PR TITLE
DPC-1169 implement v2/token

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Some variables below have a note indicating their name should be changed. These 
 | SSAS_TOKEN_BLACKLIST_CACHE_ <br/> REFRESH_MINUTES  | No | X | | Configures the number of minutes between times the token blacklist cache is refreshed from the database. |
 | BCDA_TLS_CERT        | Depends  | X |   | The cert used when the SSAS service is running in secure mode. When setting vars for AWS envs, you must include a var for the cert material. This var should be renamed to SSAS_TLS_CERT. |
 | BCDA_TLS_KEY         | Depends  | X |   | The private key used when the SSAS service is running in secure mode. When setting vars for AWS envs, you must include a var for the key material. This var should be renamed to SSAS_TLS_KEY. |
+| SSAS_CLIENT_ASSERTION_AUD         | Yes  | X |   | The audience (aud) claim value required when authenticating using client assertion tokens (v2/token). |
 
 # Development Setup
 
@@ -100,7 +101,7 @@ Note that to initialize our docker container, we use migrate-and-start, which co
 
 # Test
 
-The SSAS can be tested by running `make test-ssas` or `make unit-test-ssas`. You can also use the repo-wide commands `make test` and `make unit-test`, which will run tests against the entire repo, including the SSAS code.  Some tests are designed to be only run as needed, and are excluded from `make` by a build tag.  To include
+The SSAS can be tested by running `make unit-test`. You can also use the repo-wide commands `make test` and `make unit-test`, which will run tests against the entire repo, including the SSAS code.  Some tests are designed to be only run as needed, and are excluded from `make` by a build tag.  To include
 one of these test suites, follow the instructions at the top of the test file.
 
 # Integration Testing

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Note that to initialize our docker container, we use migrate-and-start, which co
 
 # Test
 
-The SSAS can be tested by running `make unit-test`. You can also use the repo-wide commands `make test` and `make unit-test`, which will run tests against the entire repo, including the SSAS code.  Some tests are designed to be only run as needed, and are excluded from `make` by a build tag.  To include
+The SSAS can be tested by running `make unit-test`. You can also use the repo-wide command `make test`, which will run tests against the entire repo, including the SSAS code.  Some tests are designed to be only run as needed, and are excluded from `make` by a build tag.  To include
 one of these test suites, follow the instructions at the top of the test file.
 
 # Integration Testing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,6 +37,7 @@ services:
       - SSAS_TOKEN_BLACKLIST_CACHE_REFRESH_MINUTES=5
       - SSAS_URL=http://ssas:3004
       - SSAS_PUBLIC_URL=http://ssas:3003
+      - SSAS_CLIENT_ASSERTION_AUD=http://local.testing.cms.gov/api/v2/Token/auth
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-ssas-app
   postman_test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - SSAS_TOKEN_BLACKLIST_CACHE_CLEANUP_MINUTES=15
       - SSAS_TOKEN_BLACKLIST_CACHE_TIMEOUT_MINUTES=1440
       - SSAS_TOKEN_BLACKLIST_CACHE_REFRESH_MINUTES=5
+      - SSAS_CLIENT_ASSERTION_AUD=http://local.testing.cms.gov/api/v2/Token/auth
     volumes:
       - .:/go/src/github.com/CMSgov/bcda-ssas-app
     ports:

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -26,7 +26,7 @@ func init() {
 // Server creates an SSAS admin server
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
-	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute,"")
+	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute, "")
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -26,7 +26,7 @@ func init() {
 // Server creates an SSAS admin server
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
-	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute)
+	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, adminSigningKeyPath, 20*time.Minute,"")
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -190,11 +190,11 @@ func addFixtureData() {
 	}
 	makeSystem(db, "admin", "31e029ef-0e97-47f8-873c-0e8b7e7f99bf",
 		"BCDA API Admin", "bcda-admin",
-		"nbZ5oAnTlzyzeep46bL4qDGGuidXuYxs3xknVWBKjTI=:9s/Tnqvs8M7GN6VjGkLhCgjmS59r6TaVguos8dKV9lGqC1gVG8ywZVEpDMkdwOaj8GoNe4TU3jS+OZsK3kTfEQ==",
+		"ofSsVmNaR6+nq93pGUhzKcLvJlokzE4mKqBxS8kt5Fc=:yt+N0wLzqZsY4Lw0pIEWlySbU7y7P7mNnn8IUjsZR0qis9/X2aKtjAMKlFRcCp+CYDeF/+FrvzuCDqacQwX+hA==:130000",
 	)
 	makeSystem(db, "0c527d2e-2e8a-4808-b11d-0fa06baf8254",
 		"0c527d2e-2e8a-4808-b11d-0fa06baf8254", "ACO Dev", "bcda-api",
-		"h5hF9cm0Wmm+ClnoF0+Dq5JCQFmDVtzAsaquigoYcTk=:mptcWsBLNYFylRT1q95brbfKiaQkUt8oZXml0EMXobghbVVewZeG40EfNqe10u1+RftftEMvzSCB/oG17MRpVA==")
+		"bUtFIoldpvBjK92JoJrZEQCZbjTAI0o5RRJ+krdHMFA=:iKOi8/rskQ+ykmA32f3iVNQ6SWBJbWrC0weq7K6R1LF164zKcmQ8PXa4CMUZ1kd8sBBqvP+ISTYqwDu9C+5dtA==:130000")
 }
 
 func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) {

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -478,7 +478,7 @@ func setHeaders(w http.ResponseWriter) {
 }
 
 type TokenResponse struct {
-	Scope 		string `json:"scope,omitempty"`
+	Scope       string `json:"scope,omitempty"`
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
 	ExpiresIn   string `json:"expires_in"`
@@ -547,41 +547,41 @@ func tokenV2(w http.ResponseWriter, r *http.Request) {
 	event := ssas.Event{Op: "V2-Token", TrackingID: trackingID, Help: "calling from public.tokenV2()"}
 	ssas.OperationCalled(event)
 	valError := validateClientAssertionParams(r)
-	if valError!="" {
+	if valError != "" {
 		event.Help = valError
 		ssas.AuthorizationFailure(event)
-		jsonError(w,valError, "")
+		jsonError(w, valError, "")
 		return
 	}
 
 	tokenString := r.Form.Get("client_assertion")
 	token, err := parseClientSignedToken(tokenString, trackingID)
-	if err!= nil{
+	if err != nil {
 		event.Help = err.Error()
 		ssas.AuthorizationFailure(event)
-		jsonError(w,err.Error(), "")
+		jsonError(w, err.Error(), "")
 		return
 	}
 
 	claims := token.Claims.(*service.CommonClaims)
-	if claims.Subject != claims.Issuer{
+	if claims.Subject != claims.Issuer {
 		event.Help = "subject (sub) and issuer (iss) claims do not match"
 		ssas.AuthorizationFailure(event)
-		jsonError(w,"subject (sub) and issuer (iss) claims do not match", "")
+		jsonError(w, "subject (sub) and issuer (iss) claims do not match", "")
 		return
 	}
 
-	if claims.Id =="" {
+	if claims.Id == "" {
 		event.Help = "missing Token ID (jti) claim"
 		ssas.AuthorizationFailure(event)
-		jsonError(w,"missing Token ID (jti) claim", "")
+		jsonError(w, "missing Token ID (jti) claim", "")
 		return
 	}
 
 	if claims.Audience != server.GetClientAssertionAudience() {
 		event.Help = "invalid audience (aud) claim"
 		ssas.AuthorizationFailure(event)
-		jsonError(w,"invalid audience (aud) claim", "")
+		jsonError(w, "invalid audience (aud) claim", "")
 		return
 	}
 
@@ -589,7 +589,7 @@ func tokenV2(w http.ResponseWriter, r *http.Request) {
 	if tokenDuration > 300 { //5 minute max duration
 		event.Help = "IssuedAt (iat) and ExpiresAt (exp) claims are more than 5 minutes apart"
 		ssas.AuthorizationFailure(event)
-		jsonError(w,"IssuedAt (iat) and ExpiresAt (exp) claims are more than 5 minutes apart", "")
+		jsonError(w, "IssuedAt (iat) and ExpiresAt (exp) claims are more than 5 minutes apart", "")
 		return
 	}
 
@@ -621,7 +621,7 @@ func tokenV2(w http.ResponseWriter, r *http.Request) {
 	// https://tools.ietf.org/html/rfc6749#section-5.1
 	// expires_in is duration in seconds
 	expiresIn := accessToken.Claims.(*service.CommonClaims).ExpiresAt - accessToken.Claims.(*service.CommonClaims).IssuedAt
-	m := TokenResponse{Scope:"system/*.*", AccessToken: ts, TokenType: "bearer", ExpiresIn: strconv.FormatInt(expiresIn, 10)}
+	m := TokenResponse{Scope: "system/*.*", AccessToken: ts, TokenType: "bearer", ExpiresIn: strconv.FormatInt(expiresIn, 10)}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
@@ -665,7 +665,7 @@ func validateClientAssertionParams(r *http.Request) string {
 	return ""
 }
 
-func parseClientSignedToken(jwt string, trackingID string)(*jwt.Token, error){
+func parseClientSignedToken(jwt string, trackingID string) (*jwt.Token, error) {
 	return server.VerifyClientSignedToken(jwt, trackingID)
 }
 

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -562,11 +562,19 @@ func tokenV2(w http.ResponseWriter, r *http.Request) {
 		jsonError(w,err.Error(), "")
 		return
 	}
+
 	claims := token.Claims.(*service.CommonClaims)
 	if claims.Subject != claims.Issuer{
 		event.Help = "subject (sub) and issuer (iss) claims do not match"
 		ssas.AuthorizationFailure(event)
 		jsonError(w,"subject (sub) and issuer (iss) claims do not match", "")
+		return
+	}
+
+	if claims.Id ==""{
+		event.Help = "missing Token ID (jti) claim"
+		ssas.AuthorizationFailure(event)
+		jsonError(w,"missing Token ID (jti) claim", "")
 		return
 	}
 

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -6,23 +6,24 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/go-chi/chi"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
 	"time"
-	"github.com/CMSgov/bcda-ssas-app/ssas"
-	"github.com/CMSgov/bcda-ssas-app/ssas/service"
-	"github.com/go-chi/chi"
-	"github.com/pborman/uuid"
-	"gorm.io/gorm"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type APITestSuite struct {
@@ -31,12 +32,14 @@ type APITestSuite struct {
 	db                *gorm.DB
 	server            *service.Server
 	badSigningKeyPath string
+	assertAud         string
 }
 
 func (s *APITestSuite) SetupSuite() {
 	s.db = ssas.GetGORMDbConnection()
 	s.server = Server()
 	s.badSigningKeyPath = "../../../shared_files/ssas/admin_test_signing_key.pem"
+	s.assertAud = "http://local.testing.cms.gov/api/v2/Token/auth"
 	service.StartBlacklist()
 }
 
@@ -464,8 +467,7 @@ func TestAPITestSuite(t *testing.T) {
 	suite.Run(t, new(APITestSuite))
 }
 
-//Authenticate and generate access token using JWT (v2/token/)
-func (s *APITestSuite) TestAuthenticatingWithJWT() {
+func (s *APITestSuite) SetupClientAssertionTest() (ssas.Credentials, ssas.Group, *rsa.PrivateKey) {
 	groupID := ssas.RandomHexID()[0:4]
 	group := ssas.Group{GroupID: groupID, XData: "x_data"}
 	err := s.db.Create(&group).Error
@@ -482,44 +484,388 @@ func (s *APITestSuite) TestAuthenticatingWithJWT() {
 	assert.Equal(s.T(), "Token Test", creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
-	// now for the actual test
-	token, clientAssertion, _ := mintClientAssertion(creds.SystemID,time.Now().Unix(), time.Now().Add(time.Duration(10000)).Unix(), privateKey)
+	return creds, group, privateKey
+}
 
-	claims := token.Claims.(service.CommonClaims)
-	errors := checkTokenClaims(&claims)
+//Authenticate and generate access token using JWT (v2/token/)
+func (s *APITestSuite) TestAuthenticatingWithJWT() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
 	assert.Nil(s.T(), errors)
 
-	req := httptest.NewRequest("POST", "/v2/token", nil)
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", "Bearer " + clientAssertion)
 
 	handler := http.HandlerFunc(tokenV2)
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
-	//t := TokenResponse{}
-	//assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
-	//assert.NotEmpty(s.T(), t)
-	//assert.NotEmpty(s.T(), t.AccessToken)
-	//
-	//err = ssas.CleanDatabase(group)
-	//assert.Nil(s.T(), err)
+	t := TokenResponse{}
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
+	assert.NotEmpty(s.T(), t)
+	assert.NotEmpty(s.T(), t.AccessToken)
+	assert.NotEmpty(s.T(), t.Scope)
+	assert.Equal(s.T(), "system/*.*", t.Scope)
+
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
 }
 
-func mintClientAssertion(systemID string,issuedAt int64, expiresAt int64,privateKey *rsa.PrivateKey) (*jwt.Token, string, error) {
-	claims := service.CommonClaims{
-		StandardClaims : jwt.StandardClaims{
-			Issuer : "cat",
-		},
-		TokenType: "ClientAssertion",
-	}
+func (s *APITestSuite) TestAuthenticatingWithJWTWithExpBeforeIssuedTime() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	expiresAt := time.Now().Unix()+200
+	issuedAt := expiresAt+1
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "token used before issued")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithMoreThan5MinutesExpTime() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	issuedAt := time.Now().Unix()
+	expiresAt := issuedAt+350
+
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "IssuedAt (iat) and ExpiresAt (exp) claims are more than 5 minutes apart")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithExpiredToken() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	issuedAt := time.Now().Unix()-3600 //simulate token issued an hour ago.
+	expiresAt := issuedAt+200 //exp within 5 min of iat time
+
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "Token is expired")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTSignedWithWrongKey() {
+	creds, group, _ := s.SetupClientAssertionTest() //Correct private key is created and uploaded here
+	issuedAt := time.Now().Unix()
+	expiresAt := issuedAt+200
+
+	wrongPrivateKey, _, err := ssas.GenerateTestKeys(2048)
+	require.Nil(s.T(), err)
+
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, wrongPrivateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "crypto/rsa: verification error")
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	issuedAt := time.Now().Unix()
+	expiresAt := issuedAt+200
+
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+
+	system, err := ssas.GetSystemByID(creds.SystemID)
+	assert.Nil(s.T(), err)
+	key, err := system.GetEncryptionKey(uuid.NewRandom().String())
+	assert.Nil(s.T(), err)
+
+	//Soft delete public key
+	db := ssas.GetGORMDbConnection()
+	defer ssas.Close(db)
+	assert.Nil(s.T(),s.db.Delete(&key).Error)
+
+	//Ensure record was soft deleted, and not permanently deleted.
+	key, err = system.GetEncryptionKey(uuid.NewRandom().String())
+	assert.NotNil(s.T(), err)
+	assert.Empty(s.T(), key)
+	var encryptionKey ssas.EncryptionKey
+	err = db.Unscoped().First(&encryptionKey, "system_id = ?", creds.SystemID).Error
+	assert.Nil(s.T(),err)
+	assert.NotEmpty(s.T(),encryptionKey)
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "key not found for system: "+creds.SystemID)
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingIssuerClaim() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	_, clientAssertion, errors := mintClientAssertion("", creds.SystemID, s.assertAud, time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "missing issuer (iss) in jwt claims")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithBadAudienceClaim() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, "https://invalid.url.com",time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid audience (aud) claim")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingSubjectClaim() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, "",s.assertAud, time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "subject (sub) and issuer (iss) claims do not match")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithBadScopeParam() {
+	//System does not need to be created for this test since header and param checks are done before assertion is parsed/looked up.
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Set("client_assertion", "value_does_not_matter_for_this_test")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Invalid scope value
+	form.Set("scope", "system/invalid")
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid scope value")
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithBadAcceptHeader() {
+	//System does not need to be created for this test since header and param checks are done before assertion is parsed/looked up.
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", "value_does_not_matter_for_this_test")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Invalid accept header value
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/txt")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid Accept header value. Supported types: [application/json]")
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithBadContentTypeHeader() {
+	//System does not need to be created for this test since header and param checks are done before assertion is parsed/looked up.
+	form := url.Values{}
+	form.Set("scope", "system/*.*")
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Set("client_assertion", "value_does_not_matter_for_this_test")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Missing Content-Type header
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "missing Content-Type header")
+
+	//Invalid Content-Type header value
+	req = httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/bad-type")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid Content Type Header value. Supported Types: [application/x-www-form-urlencoded]")
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithBadGrantTypeParam() {
+	//System does not need to be created for this test since header and param checks are done before assertion is parsed/looked up.
+	form := url.Values{}
+	form.Set("scope", "system/*.*")
+	form.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Set("client_assertion", "value_does_not_matter_for_this_test")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Invalid grant_type param
+	form.Set("grant_type", "invalid_grant_type")
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid value for grant_type")
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithBadClientAssertionTypeParam() {
+	//System does not need to be created for this test since header and param checks are done before assertion is parsed/looked up.
+	form := url.Values{}
+	form.Set("scope", "system/*.*")
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_assertion", "value_does_not_matter_for_this_test")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Invalid client_assertion_type param
+	form.Set("client_assertion_type", "invalid_client_assertion_type")
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "invalid value for client_assertion_type")
+}
+
+func (s *APITestSuite) TestClientAssertionAuthWithMissingClientAssertionParam() {
+	//Create system and valid client assertion token
+	form := url.Values{}
+	form.Set("scope", "system/*.*")
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	handler := http.HandlerFunc(tokenV2)
+
+	//Missing client_assertion param
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	handler.ServeHTTP(s.rr, req)
+	s.verifyErrorResponse(http.StatusBadRequest, "missing client_assertion")
+}
+
+func (s *APITestSuite) verifyErrorResponse(expectedStatus interface{}, expectedMsg string) {
+	assert.Equal(s.T(), expectedStatus, s.rr.Code)
+	t := ssas.ErrorResponse{}
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
+	assert.NotEmpty(s.T(), t)
+	assert.Equal(s.T(), expectedMsg, t.Error)
+}
+
+func mintClientAssertion(issuer string, subject string, aud string, issuedAt int64, expiresAt int64, privateKey *rsa.PrivateKey) (*jwt.Token, string, error) {
+	claims := service.CommonClaims{}
 
 	token := jwt.New(jwt.SigningMethodRS512)
 	tokenID := uuid.NewRandom().String()
+	claims.TokenType = "ClientAssertion"
 	claims.IssuedAt = issuedAt
 	claims.ExpiresAt = expiresAt
 	claims.Id = tokenID
-	claims.Issuer = systemID
+	claims.Subject = subject
+	claims.Issuer = issuer
+	claims.Audience = aud
 	token.Claims = claims
 	var signedString, err = token.SignedString(privateKey)
 	if err != nil {
@@ -527,6 +873,5 @@ func mintClientAssertion(systemID string,issuedAt int64, expiresAt int64,private
 		ssas.Logger.Errorf("token signing error %s", err)
 		return nil, "", err
 	}
-	// not emitting AccessTokenIssued here because it hasn't been given to anyone
 	return token, signedString, nil
 }

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -519,9 +519,9 @@ func (s *APITestSuite) TestAuthenticatingWithJWT() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithExpBeforeIssuedTime() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	expiresAt := time.Now().Unix()+200
-	issuedAt := expiresAt+1
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	expiresAt := time.Now().Unix() + 200
+	issuedAt := expiresAt + 1
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, issuedAt, expiresAt, privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -545,9 +545,9 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpBeforeIssuedTime() {
 func (s *APITestSuite) TestAuthenticatingWithJWTWithMoreThan5MinutesExpTime() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
 	issuedAt := time.Now().Unix()
-	expiresAt := issuedAt+350
+	expiresAt := issuedAt + 350
 
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, issuedAt, expiresAt, privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -570,10 +570,10 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMoreThan5MinutesExpTime() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithExpiredToken() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	issuedAt := time.Now().Unix()-3600 //simulate token issued an hour ago.
-	expiresAt := issuedAt+200 //exp within 5 min of iat time
+	issuedAt := time.Now().Unix() - 3600 //simulate token issued an hour ago.
+	expiresAt := issuedAt + 200          //exp within 5 min of iat time
 
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, issuedAt, expiresAt, privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -597,12 +597,12 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpiredToken() {
 func (s *APITestSuite) TestAuthenticatingWithJWTSignedWithWrongKey() {
 	creds, group, _ := s.SetupClientAssertionTest() //Correct private key is created and uploaded here
 	issuedAt := time.Now().Unix()
-	expiresAt := issuedAt+200
+	expiresAt := issuedAt + 200
 
 	wrongPrivateKey, _, err := ssas.GenerateTestKeys(2048)
 	require.Nil(s.T(), err)
 
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, wrongPrivateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, issuedAt, expiresAt, wrongPrivateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -626,9 +626,9 @@ func (s *APITestSuite) TestAuthenticatingWithJWTSignedWithWrongKey() {
 func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
 	issuedAt := time.Now().Unix()
-	expiresAt := issuedAt+200
+	expiresAt := issuedAt + 200
 
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud,issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, s.assertAud, issuedAt, expiresAt, privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -641,7 +641,6 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-
 	system, err := ssas.GetSystemByID(creds.SystemID)
 	assert.Nil(s.T(), err)
 	key, err := system.GetEncryptionKey(uuid.NewRandom().String())
@@ -650,7 +649,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	//Soft delete public key
 	db := ssas.GetGORMDbConnection()
 	defer ssas.Close(db)
-	assert.Nil(s.T(),s.db.Delete(&key).Error)
+	assert.Nil(s.T(), s.db.Delete(&key).Error)
 
 	//Ensure record was soft deleted, and not permanently deleted.
 	key, err = system.GetEncryptionKey(uuid.NewRandom().String())
@@ -658,8 +657,8 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	assert.Empty(s.T(), key)
 	var encryptionKey ssas.EncryptionKey
 	err = db.Unscoped().First(&encryptionKey, "system_id = ?", creds.SystemID).Error
-	assert.Nil(s.T(),err)
-	assert.NotEmpty(s.T(),encryptionKey)
+	assert.Nil(s.T(), err)
+	assert.NotEmpty(s.T(), encryptionKey)
 
 	handler := http.HandlerFunc(tokenV2)
 	handler.ServeHTTP(s.rr, req)
@@ -694,7 +693,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingIssuerClaim() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithBadAudienceClaim() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, "https://invalid.url.com",time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, creds.SystemID, "https://invalid.url.com", time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -722,7 +721,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
 	token := jwt.New(jwt.SigningMethodRS512)
 	claims.TokenType = "ClientAssertion"
 	claims.IssuedAt = time.Now().Unix()
-	claims.ExpiresAt =  time.Now().Add(time.Duration(100000)).Unix()
+	claims.ExpiresAt = time.Now().Add(time.Duration(100000)).Unix()
 	claims.Subject = creds.SystemID
 	claims.Issuer = creds.SystemID
 	claims.Audience = s.assertAud
@@ -750,7 +749,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingSubjectClaim() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, "",s.assertAud, time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.SystemID, "", s.assertAud, time.Now().Unix(), time.Now().Add(time.Duration(100000)).Unix(), privateKey)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -891,7 +891,6 @@ func mintClientAssertion(issuer string, subject string, aud string, issuedAt int
 
 	token := jwt.New(jwt.SigningMethodRS512)
 	tokenID := uuid.NewRandom().String()
-	claims.TokenType = "ClientAssertion"
 	claims.IssuedAt = issuedAt
 	claims.ExpiresAt = expiresAt
 	claims.Id = tokenID

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -21,7 +21,7 @@ func init() {
 	publicSigningKeyPath = os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
 	ssas.Logger.Info("public signing key sourced from ", publicSigningKeyPath)
 	clientAssertAud = os.Getenv("SSAS_CLIENT_ASSERTION_AUD")
-	ssas.Logger.Info("aud value required in client assertion tokens", clientAssertAud)
+	ssas.Logger.Info("aud value required in client assertion tokens:", clientAssertAud)
 }
 
 func Server() *service.Server {

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"os"
 	"time"
-
 	"github.com/go-chi/chi"
-
 	"github.com/CMSgov/bcda-ssas-app/ssas"
 	"github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
@@ -14,17 +12,21 @@ import (
 
 var infoMap map[string][]string
 var publicSigningKeyPath string
+var clientAssertAud string
+
 var server *service.Server
 
 func init() {
 	infoMap = make(map[string][]string)
 	publicSigningKeyPath = os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
 	ssas.Logger.Info("public signing key sourced from ", publicSigningKeyPath)
+	clientAssertAud = os.Getenv("SSAS_CLIENT_ASSERTION_AUD")
+	ssas.Logger.Info("aud value required in client assertion tokens", clientAssertAud)
 }
 
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
-	server = service.NewServer("public", ":3003", constants.Version, infoMap, routes(), unsafeMode, publicSigningKeyPath, 20*time.Minute)
+	server = service.NewServer("public", ":3003", constants.Version, infoMap, routes(), unsafeMode, publicSigningKeyPath, 20*time.Minute, clientAssertAud)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "public", ":3003")}
@@ -35,6 +37,7 @@ func Server() *service.Server {
 
 func routes() *chi.Mux {
 	router := chi.NewRouter()
+	//v1 Routes
 	router.Use(service.NewAPILogger(), service.ConnectionClose)
 	router.Post("/token", token)
 	router.Post("/introspect", introspect)
@@ -44,5 +47,7 @@ func routes() *chi.Mux {
 	router.With(parseToken, requireRegTokenAuth, readGroupID).Post("/register", RegisterSystem)
 	router.With(parseToken, requireRegTokenAuth, readGroupID).Post("/reset", ResetSecret)
 
+	//v2 Routes
+	router.Post("/v2/token", tokenV2)
 	return router
 }

--- a/ssas/service/public/tokens.go
+++ b/ssas/service/public/tokens.go
@@ -136,6 +136,10 @@ func checkTokenClaims(claims *service.CommonClaims) error {
 		if claims.Data == "" {
 			return fmt.Errorf("access token must have Data claim")
 		}
+	case "ClientAssertion":
+		if claims.Issuer == "" {
+			return fmt.Errorf("token must have Issuer (iss) claim")
+		}
 	default:
 		return fmt.Errorf("missing token type claim")
 	}

--- a/ssas/service/public/tokens.go
+++ b/ssas/service/public/tokens.go
@@ -2,11 +2,11 @@ package public
 
 import (
 	"fmt"
-	"time"
-	"github.com/dgrijalva/jwt-go"
 	"github.com/CMSgov/bcda-ssas-app/ssas"
 	"github.com/CMSgov/bcda-ssas-app/ssas/cfg"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
+	"github.com/dgrijalva/jwt-go"
+	"time"
 )
 
 var selfRegistrationTokenDuration time.Duration

--- a/ssas/service/public/tokens.go
+++ b/ssas/service/public/tokens.go
@@ -3,9 +3,7 @@ package public
 import (
 	"fmt"
 	"time"
-
 	"github.com/dgrijalva/jwt-go"
-
 	"github.com/CMSgov/bcda-ssas-app/ssas"
 	"github.com/CMSgov/bcda-ssas-app/ssas/cfg"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
@@ -136,13 +134,8 @@ func checkTokenClaims(claims *service.CommonClaims) error {
 		if claims.Data == "" {
 			return fmt.Errorf("access token must have Data claim")
 		}
-	case "ClientAssertion":
-		if claims.Issuer == "" {
-			return fmt.Errorf("token must have Issuer (iss) claim")
-		}
 	default:
 		return fmt.Errorf("missing token type claim")
 	}
-
 	return nil
 }

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -8,12 +8,10 @@ import (
 	"net/http"
 	"os"
 	"time"
-
 	"github.com/dgrijalva/jwt-go"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 	"github.com/pborman/uuid"
-
 	"github.com/CMSgov/bcda-ssas-app/ssas"
 	"github.com/CMSgov/bcda-ssas-app/ssas/cfg"
 )
@@ -34,10 +32,11 @@ type Server struct {
 	tokenSigningKey *rsa.PrivateKey
 	tokenTTL        time.Duration
 	server          http.Server
+	clientAssertAud string
 }
 
 // NewServer correctly initializes an instance of the Server type.
-func NewServer(name, port, version string, info interface{}, routes *chi.Mux, notSecure bool, signingKeyPath string, ttl time.Duration) *Server {
+func NewServer(name, port, version string, info interface{}, routes *chi.Mux, notSecure bool, signingKeyPath string, ttl time.Duration, clientAssertAud string) *Server {
 	sk, err := getPrivateKey(signingKeyPath)
 	if err != nil {
 		msg := fmt.Sprintf("bad signing key; path %s; %v", signingKeyPath, err)
@@ -57,6 +56,7 @@ func NewServer(name, port, version string, info interface{}, routes *chi.Mux, no
 	s.notSecure = notSecure
 	s.tokenSigningKey = sk
 	s.tokenTTL = ttl
+	s.clientAssertAud = clientAssertAud
 	s.server = http.Server{
 		Handler:      s.router,
 		Addr:         s.port,
@@ -196,7 +196,7 @@ func ConnectionClose(next http.Handler) http.Handler {
 // CommonClaims contains the superset of claims that may be found in the token
 type CommonClaims struct {
 	jwt.StandardClaims
-	// AccessToken, MFAToken, or RegistrationToken
+	// AccessToken, MFAToken, ClientAssertion, or RegistrationToken
 	TokenType string `json:"use,omitempty"`
 	// In an MFA token, presence of an OktaID is taken as proof of username/password authentication
 	OktaID   string `json:"oid,omitempty"`
@@ -246,7 +246,6 @@ func newTokenID() string {
 }
 
 func (s *Server) VerifyToken(tokenString string) (*jwt.Token, error) {
-
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -257,6 +256,30 @@ func (s *Server) VerifyToken(tokenString string) (*jwt.Token, error) {
 	return jwt.ParseWithClaims(tokenString, &CommonClaims{}, keyFunc)
 }
 
+func (s *Server) VerifyClientSignedToken(tokenString string, trackingId string) (*jwt.Token, error) {
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		claims := token.Claims.(*CommonClaims)
+		system,err := ssas.GetSystemByID(claims.Issuer)
+		if err !=nil {
+			return nil, err
+		}
+		key, err := system.GetEncryptionKey(trackingId)
+		if err !=nil {
+			return nil, err
+		}
+		//TODO check key key has been soft deleted
+		//if key.DeletedAt == nil {
+		pubKey,err := ssas.ReadPublicKey(key.Body)
+		if err !=nil {
+			return nil, err
+		}
+		return pubKey, nil
+	}
+	return jwt.ParseWithClaims(tokenString, &CommonClaims{}, keyFunc)
+}
 func (s *Server) CheckRequiredClaims(claims *CommonClaims, requiredTokenType string) error {
 	if claims.ExpiresAt == 0 ||
 		claims.IssuedAt == 0 ||

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -267,6 +267,7 @@ func (s *Server) VerifyClientSignedToken(tokenString string, trackingId string) 
 		}
 		system, err := ssas.GetSystemByID(claims.Issuer)
 		if err != nil {
+			ssas.Logger.Error(err)
 			return nil, fmt.Errorf("failed to retrieve system information")
 		}
 		key, err := system.GetEncryptionKey(trackingId)

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -267,7 +267,7 @@ func (s *Server) VerifyClientSignedToken(tokenString string, trackingId string) 
 		}
 		system,err := ssas.GetSystemByID(claims.Issuer)
 		if err !=nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to retrieve system information")
 		}
 		key, err := system.GetEncryptionKey(trackingId)
 		if err !=nil {
@@ -275,7 +275,8 @@ func (s *Server) VerifyClientSignedToken(tokenString string, trackingId string) 
 		}
 		pubKey,err := ssas.ReadPublicKey(key.Body)
 		if err !=nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read public key")
+
 		}
 		return pubKey, nil
 	}

--- a/ssas/service/server_test.go
+++ b/ssas/service/server_test.go
@@ -26,7 +26,7 @@ func (s *ServerTestSuite) SetupSuite() {
 }
 
 func (s *ServerTestSuite) SetupTest() {
-	s.server = NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, unitSigningKeyPath, 37*time.Minute)
+	s.server = NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, unitSigningKeyPath, 37*time.Minute,"")
 }
 
 func (s *ServerTestSuite) TestNewServer() {
@@ -45,7 +45,7 @@ func (s *ServerTestSuite) TestNewServer() {
 	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("test"))
 	})
-	ts := NewServer("test-server", ":9999", "9.99.999", s.info, r, true, unitSigningKeyPath, 37*time.Minute)
+	ts := NewServer("test-server", ":9999", "9.99.999", s.info, r, true, unitSigningKeyPath, 37*time.Minute,"")
 	assert.NotEmpty(s.T(), ts.router)
 	routes, err := ts.ListRoutes()
 	assert.Nil(s.T(), err)
@@ -105,7 +105,7 @@ func (s *ServerTestSuite) TestNYI() {
 // MintToken(), MintTokenWithDuration()
 
 func (s *ServerTestSuite) TestNewServerWithBadSigningKey() {
-	ts := NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, "", 37*time.Minute)
+	ts := NewServer("test-server", ":9999", "9.99.999", s.info, nil, true, "", 37*time.Minute,"")
 	assert.Nil(s.T(), ts)
 }
 

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -60,6 +60,7 @@ type EncryptionKey struct {
 	Body     string `json:"body"`
 	System   System `gorm:"foreignkey:SystemID;association_foreignkey:ID"`
 	SystemID uint   `json:"system_id"`
+
 }
 
 type Secret struct {

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -14,9 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
 	"github.com/CMSgov/bcda-ssas-app/ssas/cfg"
-
 	"github.com/pborman/uuid"
 	"gorm.io/gorm"
 )
@@ -74,6 +72,10 @@ type Secret struct {
 // IsExpired tests whether this secret has expired
 func (secret *Secret) IsExpired() bool {
 	return secret.UpdatedAt.Add(CredentialExpiration).Before(time.Now())
+}
+
+func (key *EncryptionKey) IsEncryptionKeyExpired() bool {
+	return key.UpdatedAt.Add(CredentialExpiration).Before(time.Now())
 }
 
 type IP struct {


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-1169](https://jira.cms.gov/browse/DPC-1169)

<!-- Describe the problem being solved here: -->
To meet the needs of DPC and follow the Bulk FHIR auth spec, we'll need to combine these capabilities. In particular, we need to provice access tokens to a system after authenticating a request presenting a JWT signed by the public key registered to the system.

To successfully authenticate:

The system ID must be present in the iss and sub claims
The aud claim must match a configurable value (that we expect to set, for instance, to https://sandbox.dpc.cms.gov/api/v2/Token/auth)
The exp and iat claims must be set no more than 5 minutes apart, and presented before expiration
The jti claim must be unique (we suggest a UUID)
The group, system, and public key must not be soft-deleted or expired
The JWT must be signed by the private key corresponding to the registered public key
The JWT must be presented in the body of the request, in the format currently required by DPC and HL7
The Content-Type header must be application/x-www-form-urlencoded
The Accept header must be application/json
To match the DPC system behavior, we need to add "scope": "system/." to the response.

Note: macaroons are not in scope for this ticket, thus we are using the system ID in the iss and sub claims and not macaroons (client tokens) as currently required by DPC.
### Proposed Changes

<!-- List of changes with bullet points here: -->

### Change Details

<!-- Add detailed discussion of changes here: -->
added v2/token endpoint
added tests
### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [x] security checklist is completed for this change
Security Checklist: https://confluence.cms.gov/pages/viewpage.action?spaceKey=DAPC&title=2021-05-29%3A+SSAS+v2+Security+Checklist

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database?  Do we know for sure that it doesn't break our client API's? -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
