### PR TITLE
BCDA 4452 Fix: Pin Postgres image version to 10 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres
+    image: postgres:10
     environment:
       - POSTGRES_DB=bcda
       - POSTGRES_PASSWORD=toor


### PR DESCRIPTION
### Fixes [BCDA-4452](https://jira.cms.gov/browse/BCDA-4452)

The current deployed major version of Postgres in AWS for ACO API is Postgres 10.  However, in the docker-compose stacks for bcda-ssas-app, we are pulling from postgres:latest (see here for example).

We need to ensure all references to pulling Postgres images from Dockerhub bcda-ssas-app align with the version of Postgres that we are using in AWS.  This should be `postgres:10` image in Dockerhub.

### Proposed Changes

- Pin `postgres:10` version

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database?  Do we know for sure that it doesn't break our client API's? -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
