### PR TITLE
Hotfix: Pin usql to version 0.8.2

### DIFF
--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -2,7 +2,7 @@ FROM golang:1.15-buster
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
-RUN GO111MODULE=on go get github.com/xo/usql
+RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
 RUN go get -u github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \


### PR DESCRIPTION
The newest version of https://github.com/xo/usql was causing build failures for our test package. This fix pins usql at the previous stable version 0.8.2.

### Change Details
Specify usql@v0.8.2 in Dockerfile.tests

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation
Builds successfully locally


### Feedback Requested
