### PR TITLE
Fix SSAS Swagger Doc Generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
-	docker-compose up --rm documentation swagger generate spec -i ../../swaggerui/tags.yml -o ../../swaggerui/swagger.json -m
+	docker-compose run --rm documentation swagger generate spec -i ../../swaggerui/tags.yml -o ../../swaggerui/swagger.json -m
 	docker build -t packaging -f Dockerfiles/Dockerfile.package .
 	docker run --rm \
 	-e BCDA_GPG_RPM_PASSPHRASE='${BCDA_GPG_RPM_PASSPHRASE}' \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 package:
 	# This target should be executed by passing in an argument representing the version of the artifacts we are packaging
 	# For example: make package version=r1
-	docker-compose up documentation
+	docker-compose up --rm documentation swagger generate spec -i ../../swaggerui/tags.yml -o ../../swaggerui/swagger.json -m
 	docker build -t packaging -f Dockerfiles/Dockerfile.package .
 	docker run --rm \
 	-e BCDA_GPG_RPM_PASSPHRASE='${BCDA_GPG_RPM_PASSPHRASE}' \


### PR DESCRIPTION
SSAS swagger generation stopped working after Jenkins was upgraded.  

### Proposed Changes

- Explicitly run the `swagger generation ...` command from the Makefile (within the SSAS container) to generate the swagger docs.

### Change Details

- Instead of relying on the images `CMD` (which 

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

The SSAS Build and Package job executes [successfully](https://bcda-ci.adhocteam.us/job/SSAS%20-%20Build%20and%20Package/1508/) from this feature branch.

### Feedback Requested

Please review.
