### PR TITLE
DPC-1684 Used KID to lookup encryption key. (POST /v2/token)

### DIFF
--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -496,13 +496,13 @@ func (s *APITestSuite) TestGetPublicKeyRotation() {
 		s.FailNow(err.Error())
 	}
 
-	key1, _, _ := ssas.GeneratePublicKey(2048)
+	key1, _, _, _ := ssas.GeneratePublicKey(2048)
 	rk1, err := system.SavePublicKey(strings.NewReader(key1), "")
 	if err != nil {
 		s.FailNow(err.Error())
 	}
 
-	key2, _, _ := ssas.GeneratePublicKey(2048)
+	key2, _, _, _ := ssas.GeneratePublicKey(2048)
 	rk2, err := system.SavePublicKey(strings.NewReader(key2), "")
 	if err != nil {
 		s.FailNow(err.Error())
@@ -1166,7 +1166,7 @@ func (s *APITestSuite) TestCreateAndDeleteAdditionalV2SystemToken() {
 func (s *APITestSuite) TestCreateAndDeletePublicKey() {
 	creds, _ := ssas.CreateTestXDataV2(s.T(), s.db)
 
-	key, sig, _ := ssas.GeneratePublicKey(2048)
+	key, sig, _, _ := ssas.GeneratePublicKey(2048)
 	keyStr := strings.Replace(key, "\n", "\\n", -1)
 	req := httptest.NewRequest("POST", fmt.Sprintf("/v2/system/%s/key", creds.SystemID), strings.NewReader(fmt.Sprintf(`{"public_key":"%s", "signature":"%s"}`, keyStr, sig)))
 	rctx := chi.NewRouteContext()

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -269,7 +269,7 @@ func newAdminSystem(name string) {
 		c   ssas.Credentials
 		u   uint64
 	)
-	if pk, _, err = ssas.GeneratePublicKey(2048); err != nil {
+	if pk, _, _, err = ssas.GeneratePublicKey(2048); err != nil {
 		ssas.Logger.Errorf("no public key; %s", err)
 		return
 	}

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -499,7 +499,7 @@ func (s *APITestSuite) SetupClientAssertionTest() (ssas.Credentials, ssas.Group,
 //Authenticate and generate access token using JWT (v2/token/)
 func (s *APITestSuite) TestAuthenticatingWithJWT() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -526,12 +526,73 @@ func (s *APITestSuite) TestAuthenticatingWithJWT() {
 	assert.Nil(s.T(), err)
 }
 
+//Authenticate and generate access token using JWT (v2/token/)
+func (s *APITestSuite) TestAuthenticatingWithJWTUsingSecondPublicKey() {
+	creds, group, _ := s.SetupClientAssertionTest()
+	system, _ := ssas.GetSystemByID(creds.SystemID)
+	pubK, sig, newPrivateKey, _ := ssas.GeneratePublicKey(2048)
+	secondKey, _ := system.AddAdditionalPublicKey(strings.NewReader(pubK), sig)
+
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), newPrivateKey, secondKey.UUID)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
+	t := TokenResponse{}
+	assert.NoError(s.T(), json.NewDecoder(s.rr.Body).Decode(&t))
+	assert.NotEmpty(s.T(), t)
+	assert.NotEmpty(s.T(), t.AccessToken)
+	assert.NotEmpty(s.T(), t.Scope)
+	assert.Equal(s.T(), "system/*.*", t.Scope)
+
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTUsingWrongPrivateKey() {
+	creds, group, firstPrivateKey := s.SetupClientAssertionTest()
+	system, _ := ssas.GetSystemByID(creds.SystemID)
+	pubK, sig, _, _ := ssas.GeneratePublicKey(2048)
+	secondKey, _ := system.AddAdditionalPublicKey(strings.NewReader(pubK), sig)
+
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), firstPrivateKey, secondKey.UUID)
+	assert.Nil(s.T(), errors)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", clientAssertion)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
+	s.verifyErrorResponse(http.StatusBadRequest, "crypto/rsa: verification error")
+	err := ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
 func (s *APITestSuite) TestAuthenticatingWithMismatchLocation() {
 	os.Setenv("SSAS_MACAROON_LOCATION", "localpost")
 	creds, group, privateKey := s.SetupClientAssertionTest()
 	os.Unsetenv("SSAS_MACAROON_LOCATION")
 
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -555,7 +616,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpBeforeIssuedTime() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
 	expiresAt := time.Now().Unix() + 200
 	issuedAt := expiresAt + 1
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -581,7 +642,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMoreThan5MinutesExpTime() {
 	issuedAt := time.Now().Unix()
 	expiresAt := issuedAt + 350
 
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -607,7 +668,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpiredToken() {
 	issuedAt := time.Now().Unix() - 3600 //simulate token issued an hour ago.
 	expiresAt := issuedAt + 200          //exp within 5 min of iat time
 
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -636,7 +697,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTSignedWithWrongKey() {
 	wrongPrivateKey, _, err := ssas.GenerateTestKeys(2048)
 	require.Nil(s.T(), err)
 
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, wrongPrivateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, wrongPrivateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -662,7 +723,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	issuedAt := time.Now().Unix()
 	expiresAt := issuedAt + 200
 
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, s.assertAud, issuedAt, expiresAt, privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -704,7 +765,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingIssuerClaim() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion("", creds.SystemID, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion("", creds.SystemID, s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -727,7 +788,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingIssuerClaim() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithBadAudienceClaim() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, "https://invalid.url.com", time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, creds.ClientToken, "https://invalid.url.com", time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -748,7 +809,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithBadAudienceClaim() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
+func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingKID() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
 	claims := service.CommonClaims{}
 
@@ -776,6 +837,40 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
 	handler := http.HandlerFunc(tokenV2)
 	handler.ServeHTTP(s.rr, req)
 
+	s.verifyErrorResponse(http.StatusBadRequest, "missing public key id (kid) in jwt header")
+	err = ssas.CleanDatabase(group)
+	assert.Nil(s.T(), err)
+}
+
+func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
+	creds, group, privateKey := s.SetupClientAssertionTest()
+	claims := service.CommonClaims{}
+
+	token := jwt.New(jwt.SigningMethodRS512)
+	claims.TokenType = "ClientAssertion"
+	claims.IssuedAt = time.Now().Unix()
+	claims.ExpiresAt = time.Now().Add(time.Minute * 5).Unix()
+	claims.Subject = creds.ClientToken
+	claims.Issuer = creds.ClientToken
+	claims.Audience = s.assertAud
+	token.Header["kid"] = creds.PublicKeyID
+	token.Claims = claims
+	var signedString, err = token.SignedString(privateKey)
+	assert.Nil(s.T(), err)
+
+	form := url.Values{}
+	form.Add("scope", "system/*.*")
+	form.Add("grant_type", "client_credentials")
+	form.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	form.Add("client_assertion", signedString)
+
+	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	handler := http.HandlerFunc(tokenV2)
+	handler.ServeHTTP(s.rr, req)
+
 	s.verifyErrorResponse(http.StatusBadRequest, "missing Token ID (jti) claim")
 	err = ssas.CleanDatabase(group)
 	assert.Nil(s.T(), err)
@@ -783,7 +878,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingJTI() {
 
 func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingSubjectClaim() {
 	creds, group, privateKey := s.SetupClientAssertionTest()
-	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, "", s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey)
+	_, clientAssertion, errors := mintClientAssertion(creds.ClientToken, "", s.assertAud, time.Now().Unix(), time.Now().Add(time.Minute*5).Unix(), privateKey, creds.PublicKeyID)
 	assert.Nil(s.T(), errors)
 
 	form := url.Values{}
@@ -920,7 +1015,7 @@ func (s *APITestSuite) verifyErrorResponse(expectedStatus interface{}, expectedM
 	assert.Equal(s.T(), expectedMsg, t.Error)
 }
 
-func mintClientAssertion(issuer string, subject string, aud string, issuedAt int64, expiresAt int64, privateKey *rsa.PrivateKey) (*jwt.Token, string, error) {
+func mintClientAssertion(issuer, subject, aud string, issuedAt, expiresAt int64, privateKey *rsa.PrivateKey, kid string) (*jwt.Token, string, error) {
 	claims := service.CommonClaims{}
 
 	token := jwt.New(jwt.SigningMethodRS512)
@@ -932,6 +1027,7 @@ func mintClientAssertion(issuer string, subject string, aud string, issuedAt int
 	claims.Issuer = issuer
 	claims.Audience = aud
 	token.Claims = claims
+	token.Header["kid"] = kid
 	var signedString, err = token.SignedString(privateKey)
 	if err != nil {
 		ssas.TokenMintingFailure(ssas.Event{TokenID: tokenID})

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -340,7 +340,13 @@ func (s *Server) VerifyClientSignedToken(tokenString string, trackingId string) 
 			ssas.Logger.Error(err)
 			return nil, fmt.Errorf("failed to retrieve system information")
 		}
-		key, err := system.GetEncryptionKey(trackingId)
+
+		kid := token.Header["kid"]
+		if kid == nil {
+			return nil, fmt.Errorf("missing public key id (kid) in jwt header")
+		}
+
+		key, err := system.FindEncryptionKey(trackingId, kid.(string))
 		if err != nil {
 			ssas.Logger.Error(err)
 			return nil, fmt.Errorf("key not found for system: %v", claims.Issuer)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -317,7 +317,7 @@ func (system *System) FindEncryptionKey(trackingID string, keyId string) (Encryp
 	err := db.First(&encryptionKey, "system_id = ? AND uuid=?", system.ID, keyId).Error
 	if err != nil {
 		OperationFailed(findKeyEvent)
-		return encryptionKey, fmt.Errorf("cannot find key for systemId %d: %s and keyId: %s", system.ID, keyId, err.Error())
+		return encryptionKey, fmt.Errorf("cannot find key for systemId %d: and keyId: %s error: %s", system.ID, keyId, err.Error())
 	}
 
 	OperationSucceeded(findKeyEvent)

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -304,6 +304,27 @@ func (system *System) GetEncryptionKey(trackingID string) (EncryptionKey, error)
 }
 
 /*
+	FindEncryptionKey retrieves the key by id associated with the current system.
+*/
+func (system *System) FindEncryptionKey(trackingID string, keyId string) (EncryptionKey, error) {
+	db := GetGORMDbConnection()
+	defer Close(db)
+
+	findKeyEvent := Event{Op: "FindEncryptionKey", TrackingID: trackingID, ClientID: system.ClientID}
+	OperationStarted(findKeyEvent)
+
+	var encryptionKey EncryptionKey
+	err := db.First(&encryptionKey, "system_id = ? AND uuid=?", system.ID, keyId).Error
+	if err != nil {
+		OperationFailed(findKeyEvent)
+		return encryptionKey, fmt.Errorf("cannot find key for systemId %d: %s and keyId: %s", system.ID, keyId, err.Error())
+	}
+
+	OperationSucceeded(findKeyEvent)
+	return encryptionKey, nil
+}
+
+/*
 	GetEncryptionKeys retrieves the keys associated with the current system.
 */
 func (system *System) GetEncryptionKeys(trackingID string) ([]EncryptionKey, error) {
@@ -486,6 +507,7 @@ type Credentials struct {
 	IPs          []string  `json:"ips,omitempty"`
 	ExpiresAt    time.Time `json:"expires_at"`
 	XData        string    `json:"xdata,omitempty"`
+	PublicKeyID  string    `json:"public_key_id"`
 }
 
 /*
@@ -598,12 +620,14 @@ func registerSystem(input SystemInput, isV2 bool) (Credentials, error) {
 	}
 
 	if input.PublicKey != "" {
-		if _, err := system.SavePublicKeyDB(strings.NewReader(input.PublicKey), input.Signature, !isV2, tx); err != nil {
+		key, err := system.SavePublicKeyDB(strings.NewReader(input.PublicKey), input.Signature, !isV2, tx)
+		if err != nil {
 			regEvent.Help = "error in saving public key: " + err.Error()
 			OperationFailed(regEvent)
 			tx.Rollback()
 			return creds, errors.New("error in public key")
 		}
+		creds.PublicKeyID = key.UUID
 	}
 
 	if isV2 {

--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -293,7 +293,7 @@ func (s *SystemsTestSuite) TestSystemPublicKeyEmpty() {
 	assert.Nil(err)
 
 	emptyPEM := "-----BEGIN RSA PUBLIC KEY-----    -----END RSA PUBLIC KEY-----"
-	validPEM, _, err := generatePublicKey(2048)
+	validPEM, _, _, err := generatePublicKey(2048)
 	assert.Nil(err)
 
 	_, err = system.SavePublicKey(strings.NewReader(""), "")
@@ -410,7 +410,7 @@ func (s *SystemsTestSuite) TestRegisterSystemSuccess() {
 		s.FailNow(err.Error())
 	}
 
-	pubKey, _, err := generatePublicKey(2048)
+	pubKey, _, _, err := generatePublicKey(2048)
 	assert.Nil(err)
 
 	creds, err := RegisterSystem("Create System Test", groupID, DefaultScope, pubKey, []string{}, trackingID)
@@ -433,7 +433,7 @@ func (s *SystemsTestSuite) TestUpdateSystemSuccess() {
 		s.FailNow(err.Error())
 	}
 
-	pubKey, _, err := generatePublicKey(2048)
+	pubKey, _, _, err := generatePublicKey(2048)
 	assert.Nil(err)
 
 	creds, err := RegisterSystem("Create System Test", groupID, DefaultScope, pubKey, []string{}, trackingID)
@@ -486,7 +486,7 @@ func (s *SystemsTestSuite) TestRegisterSystemMissingData() {
 		s.FailNow(err.Error())
 	}
 
-	pubKey, _, err := generatePublicKey(2048)
+	pubKey, _, _, err := generatePublicKey(2048)
 	assert.Nil(err)
 
 	// No clientName
@@ -533,7 +533,7 @@ func (s *SystemsTestSuite) TestRegisterSystemIps() {
 		s.FailNow(err.Error())
 	}
 
-	pubKey, _, err := generatePublicKey(2048)
+	pubKey, _, _, err := generatePublicKey(2048)
 	assert.Nil(err)
 
 	for _, address := range goodIps {
@@ -580,7 +580,7 @@ func (s *SystemsTestSuite) TestRegisterSystemBadKey() {
 		s.FailNow(err.Error())
 	}
 
-	pubKey, _, err := generatePublicKey(1024)
+	pubKey, _, _, err := generatePublicKey(1024)
 	assert.Nil(err)
 
 	// Blank key ok
@@ -601,7 +601,7 @@ func (s *SystemsTestSuite) TestRegisterSystemBadKey() {
 	assert.Nil(CleanDatabase(group))
 }
 
-func generatePublicKey(bits int) (string, string, error) {
+func generatePublicKey(bits int) (string, string, *rsa.PrivateKey, error) {
 	return GeneratePublicKey(bits)
 }
 


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-1684](https://jira.cms.gov/browse/DPC-1684)

<!-- Describe the problem being solved here: -->
During a SSAS debugging of POST /v2/token session with Jonathan Fulk and William Huang it was discovered that SSAS was always using the the first public key (uploaded during system creation) to verify the client assertion.

This is an issue when more than one public key is uploaded, the client assertion could be signed with a second private key (linked to the second public key), but the first public key would be used.

This is due to SSAS looking up the encryption key by system id instead of using the 'kid' specified in the signed JWT

It was also discovered that the UUID of the public key created during system creation was not being returned. Not a big issue since the web portal (our only user of POST /v2/System) is not using this value, instead it is calling GET /v2/system to retrieve all public keys and ids.

### Proposed Changes
SSAS POST /v2/Token should use the jwt's 'kid' found in the tokens header.
<!-- List of changes with bullet points here: -->

### Change Details

- Added new method to lookup encryption key by UUID
- Returned 'public_key_id' when a new system is created.
- Used the encryption key specified in JTW kid

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies
No new software dependencies.
<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [x] security controls or supporting software altered
Yes, to fix a bug. Previously only the first encryption would be used, now the client may specify what public to to use for assertion verification (public key must belong to client/system)
<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted
No new data is stored or transmitted.
<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change
No, a security check list was not completed for this specific change. This is a bugfix for an existing authentication mechanism specified in the SSAS V2 Security checklist: https://confluence.cms.gov/pages/viewpage.action?spaceKey=DAPC&title=2021-04-29%3A+SSAS+v2+Security+Checklist
<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [x] requires more information or team discussion to evaluate security implications
Is a security check list required fo this change?
<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change
No PHI/PII related changes.
<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Yes, via unit test.
<!-- Insert screenshots if applicable (drag images here) -->
<img width="498" alt="Screen Shot 2021-09-01 at 6 17 04 PM" src="https://user-images.githubusercontent.com/43150956/131766380-a89a72df-f2e3-4c0e-8e94-8c6db440da61.png">

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database?  Do we know for sure that it doesn't break our client API's? -->

### Feedback Requested
- Do we need a security check list for this change?
- Does web app need to make any changes?
<!-- What type of feedback you want from your reviewers? -->
