### PR TITLE
Pin GoSec to Stable Version 2.9.1

### DIFF
--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,10 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN GO111MODULE=on go get -u github.com/securego/gosec/cmd/gosec@v2-v2.9.1
+RUN go get -u -d github.com/securego/gosec/cmd/gosec; \
+    cd $GOPATH/src/github.com/securego/gosec/cmd/gosec; \
+    git checkout v2.9.1; \
+    go build -tags 'gosec' -ldflags="-X main.Version=$(git describe --tags)" -o $GOPATH/bin/gosec github.com/securego/gosec/cmd/gosec
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,7 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN go get -u github.com/securego/gosec/cmd/gosec@v2.9.1
+RUN go get -u github.com/securego/gosec@v2.9.1
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,7 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN go get -u github.com/securego/gosec/cmd/gosec
+RUN go get -u github.com/securego/gosec/cmd/gosec@v2.9.1
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,7 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN GO111MODULE=on go get -u github.com/securego/cmd/gosec@v2.9.1
+RUN GO111MODULE=on go get -u github.com/securego/gosec/cmd/gosec@v2.9.1
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,7 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN go get -u github.com/securego/gosec@v2.9.1
+RUN GO111MODULE=on go get -u github.com/securego/cmd/gosec@v2.9.1
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -3,7 +3,7 @@ FROM golang:1.15-buster
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 RUN GO111MODULE=on go get github.com/xo/usql@v0.8.2
-RUN GO111MODULE=on go get -u github.com/securego/gosec/cmd/gosec@v2.9.1
+RUN GO111MODULE=on go get -u github.com/securego/gosec/cmd/gosec@v2-v2.9.1
 RUN go get -u gotest.tools/gotestsum
 RUN go get -u -d github.com/golang-migrate/migrate/cmd/migrate; \
     cd $GOPATH/src/github.com/golang-migrate/migrate/cmd/migrate; \


### PR DESCRIPTION
There was a recent change to `gosec` in which it updated dependencies to phase out Go 1.15.  Because BCDA SSAS is still on Go 1.15, we must pin `gosec`.
The recent change can be found [here](https://github.com/securego/gosec/pull/725), and the error in our stack can be found [here](https://bcda-ci.adhocteam.us/job/SSAS%20-%20Build%20and%20Package/1822/console).

### Change Details

Pin `gosec` to the most recent stable version, supported by the current version of Go that we use.


### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Local CI is now passing (see [here](https://github.com/CMSgov/bcda-ssas-app/actions/runs/1509250995)).
Jenkins CI is now passing (see [here](https://bcda-ci.adhocteam.us/job/SSAS%20-%20Build%20and%20Package/1826/)).
[A ticket has been created](https://jira.cms.gov/browse/BCDA-5010) to upgrade to the latest version of Go.

### Feedback Requested

Please review.
