### PR TITLE
DPC-2036: Update Logfile permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ environmental variables. It is also possible to run individual tests, but that m
 docker run --rm --network bcda-ssas-app_default -it postgres pg_dump -s -h bcda-ssas-app_db_1 -U postgres bcda > schema.sql
 ```
 ```
-docker-compose run --rm ssas sh -c 'main --reset-secret --client-id=[client_id]'
+docker-compose run --rm ssas sh -c 'ssas --reset-secret --client-id=[client_id]'
 ```
 ```
-docker-compose run --rm ssas sh -c 'main --list-ips'
+docker-compose run --rm ssas sh -c 'ssas --list-ips'
 ```
 ```
-docker-compose run --rm ssas sh -c 'main --new-admin-system --system-name=[entity name]'
+docker-compose run --rm ssas sh -c 'ssas --new-admin-system --system-name=[entity name]'
 ```
 
 # Swagger Documentation

--- a/ssas/logger.go
+++ b/ssas/logger.go
@@ -28,8 +28,8 @@ func init() {
 
 	filePath, success := os.LookupEnv("SSAS_LOG")
 	if success {
-		/* #nosec -- 0640 permissions required for Splunk ingestion */
-		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+		/* #nosec -- 0664 permissions required for Splunk ingestion */
+		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0664)
 
 		if err == nil {
 			Logger.SetOutput(file)


### PR DESCRIPTION
### Fixes [DPC-2036](https://jira.cms.gov/browse/DPC-2036)
DPC is experiencing issues with Splunk intermittently refusing to continue ingesting SSAS logs due to lack of permissions. This PR proposes to set SSAS logfile permissions to the same level used by other services.

### Proposed Changes
- Set log permissions to allow group writes and universal reads
- Update README examples

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [x] security checklist is completed for this change
[Security checklist](https://confluence.cms.gov/display/DAPC/2022-01-04%3A+SSAS+log+permissions+Security+Checklist)
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

Note that this PR:
1. Updates the file permissions to match those in use by other services using SSAS
2. Is expected to fix an intermittent (but frequent) issue where Splunk stops ingesting logs

### Acceptance Validation
#### ACO API tests pass
![Screen Shot 2022-01-04 at 1 10 26 PM](https://user-images.githubusercontent.com/2533561/148104353-d692b65c-f82e-4b66-b920-194b37df9e75.png)

#### DPC logfile permissions do change
##### Top entry is a different service's logfile; Middle entry is new SSAS logfile; bottom entry is a previous SSAS logfile
![Screen Shot 2022-01-04 at 2 02 53 PM](https://user-images.githubusercontent.com/2533561/148110480-752fad9e-e0d2-488a-a85c-40e510000533.png)


### Feedback Requested
Any concerns?