### PR TITLE
Pin Go-Swagger to v0.28.0

### DIFF
--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -3,7 +3,12 @@ RUN apk update upgrade
 RUN apk add git build-base gcc
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
 COPY . .
-RUN go get -u github.com/go-swagger/go-swagger/cmd/swagger
+
+RUN dir=$(mktemp -d) && \
+    git clone -b v0.28.0 https://github.com/go-swagger/go-swagger "$dir" && \
+    cd "$dir" && \
+    go install ./cmd/swagger
+
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app/ssas/service/main
 RUN swagger generate spec -i ../../swaggerui/tags.yml -o ../../swaggerui/swagger.json -m
 


### PR DESCRIPTION
The latest tagged version of `go-swagger` relies on some Go 1.16 features.  This [new version](https://github.com/go-swagger/go-swagger/releases/tag/v0.29.0) was released on 1/23/22. 
 When attempting to use it, [errors occur](https://bcda-ci.adhocteam.us/blue/organizations/jenkins/SSAS%20-%20Build%20and%20Package/detail/SSAS%20-%20Build%20and%20Package/1911/pipeline).


### Proposed Changes

Pin to `go-swagger` v0.28.0

### Change Details

- Pinned to `go-swagger` v0.28.0
- A [ticket exists](https://jira.cms.gov/browse/BCDA-5010) for upgrading Go

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

The full Build/Package/Deploy process is passing.  See [here](https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/2984/).

### Feedback Requested

Please review.
