### PR TITLE
Update smoke test to match 401 bad creds response

### DIFF
--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -1482,7 +1482,7 @@
 									"var ajv = new Ajv({schemas: [schema]});",
 									"",
 									"pm.test(\"Response is 'bad request'\", function () {",
-									"    pm.response.to.have.status(400);",
+									"    pm.response.to.have.status(401);",
 									"});",
 									"",
 									"pm.test('Schema is valid', function() {",


### PR DESCRIPTION
Updates smoke tests to correct response from a request with bad credentials (401 instead of 400)
