### PR TITLE
return err when invalid client secret

### DIFF
--- a/ssas/constants/constants.go
+++ b/ssas/constants/constants.go
@@ -2,3 +2,13 @@ package constants
 
 // This is set during compilation.  See build_and_package.sh in the /ops directory
 var Version = "latest"
+
+//const ApplicationJson = ""
+
+const InvalidClientSecret = "invalid client secret"
+
+const TestSystemName = "Token Test"
+
+const TokenEndpoint = "/token"
+
+const HeaderApplicationJSON = "application/json"

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -542,7 +542,7 @@ func ValidateSecret(system ssas.System, secret string, w http.ResponseWriter, r 
 	} else if !ssas.Hash(savedSecret.Hash).IsHashOf(secret) {
 		ssas.Logger.Errorf("The incoming client secret is invalid")
 		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "invalid client secret")
-		return err
+		return errors.New("invalid client secret")
 	}
 
 	if savedSecret.IsExpired() {

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 	"github.com/go-chi/render"
 	"github.com/golang-jwt/jwt/v4"
@@ -541,8 +542,8 @@ func ValidateSecret(system ssas.System, secret string, w http.ResponseWriter, r 
 		return err
 	} else if !ssas.Hash(savedSecret.Hash).IsHashOf(secret) {
 		ssas.Logger.Errorf("The incoming client secret is invalid")
-		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "invalid client secret")
-		return errors.New("invalid client secret")
+		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), constants.InvalidClientSecret)
+		return errors.New(constants.InvalidClientSecret)
 	}
 
 	if savedSecret.IsExpired() {

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v4"
@@ -305,15 +306,15 @@ func (s *APITestSuite) TestTokenSuccess() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem(constants.TestSystemName, groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
 	// now for the actual test
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(token)
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
@@ -338,9 +339,9 @@ func (s *APITestSuite) TestTokenErrAtGenerateTokenReturn401() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem(constants.TestSystemName, groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
 	//setup mocks
@@ -349,9 +350,9 @@ func (s *APITestSuite) TestTokenErrAtGenerateTokenReturn401() {
 	SetMockAccessTokenCreator(s.T(), mock)
 
 	//setup API request
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 
 	handler := http.HandlerFunc(token)
 
@@ -380,14 +381,14 @@ func (s *APITestSuite) TestTokenEmptySecretProduces401() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem(constants.TestSystemName, groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth(creds.ClientID, "")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(token)
 
 	handler.ServeHTTP(s.rr, req)
@@ -412,14 +413,14 @@ func (s *APITestSuite) TestTokenWrongSecretProduces401() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem(constants.TestSystemName, groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth(creds.ClientID, "eogihfogihegoihego")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(token)
 
 	handler.ServeHTTP(s.rr, req)
@@ -444,14 +445,14 @@ func (s *APITestSuite) TestTokenEmptyClientIdProduces401() {
 	pemString, err := ssas.ConvertPublicKeyToPEMString(&pubKey)
 	require.Nil(s.T(), err)
 
-	creds, err := ssas.RegisterSystem("Token Test", groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
+	creds, err := ssas.RegisterSystem(constants.TestSystemName, groupID, ssas.DefaultScope, pemString, []string{}, uuid.NewRandom().String())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth("", creds.ClientSecret)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(token)
 
 	handler.ServeHTTP(s.rr, req)
@@ -502,8 +503,8 @@ func (s *APITestSuite) testIntrospectFlaw(flaw service.TokenFlaw, errorText stri
 	body := strings.NewReader(fmt.Sprintf(`{"token":"%s"}`, signedString))
 	req := httptest.NewRequest("POST", "/introspect", body)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", constants.HeaderApplicationJSON)
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(introspect)
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
@@ -533,9 +534,9 @@ func (s *APITestSuite) TestIntrospectFailure() {
 func (s *APITestSuite) TestIntrospectSuccess() {
 	creds, group := ssas.CreateTestXData(s.T(), s.db)
 
-	req := httptest.NewRequest("POST", "/token", nil)
+	req := httptest.NewRequest("POST", constants.TokenEndpoint, nil)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler := http.HandlerFunc(token)
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
@@ -548,8 +549,8 @@ func (s *APITestSuite) TestIntrospectSuccess() {
 	body := strings.NewReader(fmt.Sprintf(`{"token":"%s"}`, t.AccessToken))
 	req = httptest.NewRequest("POST", "/introspect", body)
 	req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", constants.HeaderApplicationJSON)
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	handler = http.HandlerFunc(introspect)
 	handler.ServeHTTP(s.rr, req)
 	assert.Equal(s.T(), http.StatusOK, s.rr.Code)
@@ -623,7 +624,7 @@ func (s *APITestSuite) SetupClientAssertionTest() (ssas.Credentials, ssas.Group,
 	require.Nil(s.T(), err)
 
 	si := ssas.SystemInput{
-		ClientName: "Token Test",
+		ClientName: constants.TestSystemName,
 		GroupID:    groupID,
 		Scope:      ssas.DefaultScope,
 		PublicKey:  pemString,
@@ -633,7 +634,7 @@ func (s *APITestSuite) SetupClientAssertionTest() (ssas.Credentials, ssas.Group,
 	}
 	creds, err := ssas.RegisterV2System(si)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), "Token Test", creds.ClientName)
+	assert.Equal(s.T(), constants.TestSystemName, creds.ClientName)
 	assert.NotNil(s.T(), creds.ClientSecret)
 
 	return creds, group, privateKey
@@ -652,7 +653,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWT() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -731,7 +732,7 @@ func (s *APITestSuite) TestAuthenticatingWithMismatchLocation() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -755,7 +756,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpBeforeIssuedTime() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -781,7 +782,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMoreThan5MinutesExpTime() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -807,7 +808,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithExpiredToken() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -836,7 +837,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTSignedWithWrongKey() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -862,7 +863,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithSoftDeletedPublicKey() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	system, err := ssas.GetSystemByID(creds.SystemID)
@@ -904,7 +905,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingIssuerClaim() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -927,7 +928,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithBadAudienceClaim() {
 	form.Add("client_assertion", clientAssertion)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -960,7 +961,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingKID() {
 	form.Add("client_assertion", signedString)
 
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	handler := http.HandlerFunc(tokenV2)
@@ -1016,7 +1017,7 @@ func (s *APITestSuite) TestAuthenticatingWithJWTWithMissingSubjectClaim() {
 
 func buildClientAssertionRequest(form url.Values) *http.Request {
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	return req
 }
@@ -1041,7 +1042,7 @@ func (s *APITestSuite) TestClientAssertionAuthWithBadScopeParam() {
 	//Invalid scope value
 	form.Set("scope", "system/invalid")
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", constants.HeaderApplicationJSON)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	handler.ServeHTTP(s.rr, req)
 	s.verifyErrorResponse(http.StatusBadRequest, "invalid scope value")
@@ -1067,13 +1068,13 @@ func (s *APITestSuite) TestClientAssertionAuthWithBadContentTypeHeader() {
 
 	//Missing Content-Type header
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", constants.HeaderApplicationJSON)
 	handler.ServeHTTP(s.rr, req)
 	s.verifyErrorResponse(http.StatusBadRequest, "missing Content-Type header")
 
 	//Invalid Content-Type header value
 	req = httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", constants.HeaderApplicationJSON)
 	req.Header.Set("Content-Type", "application/bad-type")
 	handler.ServeHTTP(s.rr, req)
 	s.verifyErrorResponse(http.StatusBadRequest, "invalid Content Type Header value. Supported Types: [application/x-www-form-urlencoded]")
@@ -1087,7 +1088,7 @@ func (s *APITestSuite) TestClientAssertionAuthWithBadGrantTypeParam() {
 
 	//Invalid grant_type param
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	handler.ServeHTTP(s.rr, req)
 	s.verifyErrorResponse(http.StatusBadRequest, "invalid value for grant_type")
@@ -1101,7 +1102,7 @@ func (s *APITestSuite) TestClientAssertionAuthWithBadClientAssertionTypeParam() 
 	//Invalid client_assertion_type param
 	form.Set("client_assertion_type", "invalid_client_assertion_type")
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", constants.HeaderApplicationJSON)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	handler.ServeHTTP(s.rr, req)
 	s.verifyErrorResponse(http.StatusBadRequest, "invalid value for client_assertion_type")
@@ -1115,7 +1116,7 @@ func (s *APITestSuite) TestClientAssertionAuthWithMissingClientAssertionParam() 
 
 	//Missing client_assertion param
 	req := httptest.NewRequest("POST", "/v2/token", strings.NewReader(form.Encode()))
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", constants.HeaderApplicationJSON)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	handler.ServeHTTP(s.rr, req)


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `bcda-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [BCDA-6790](https://jira.cms.gov/browse/BCDA-6790)

<!-- Describe the problem being solved here: -->

### Proposed Changes

<!-- List of changes with bullet points here: -->

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

Added in unit test coverage for confirming access_token does not appear in the response body for /token endpoint

<!-- Insert screenshots if applicable (drag images here) -->

<!-- Did you deploy this feature branch to the AWS `dev` environment?  https://bcda-ci.adhocteam.us/job/BCDA%20-%20Build%20and%20Package/build 
<!-- If not, why does this change not break CI/CD?  How is it not affected by using a persistent
  database?  Do we know for sure that it doesn't break our client API's? -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
