### PR TITLE
Increase Get Access Token request timeout

### DIFF
--- a/test/postman_test/SSAS_Smoke_Test.postman_collection.json
+++ b/test/postman_test/SSAS_Smoke_Test.postman_collection.json
@@ -2532,7 +2532,7 @@
 									"postman.setEnvironmentVariable(\"jwt_token\", sJWT);",
 									"",
 									"// slow down this request to ensure token is not \"used before issued\"",
-									"setTimeout(function(){}, 300);"
+									"setTimeout(function(){}, 3000);"
 								],
 								"type": "text/javascript"
 							}


### PR DESCRIPTION
## 🎫 Ticket

<>

## 🛠 Changes

Upping the timeout function to wait for 3 s instead of 300 ms during the `public Get Access Token` smoke test. 

## ℹ️ Context for reviewers

Smoke test pipeline will pass/fail intermittently, typically on the test to retrieve a token. This delays deployments and also makes complicates the addition of new smoke tests.

## ✅ Acceptance Validation

To be tested in jenkins, no negative impacts with the exception of a 3 second longer run time.

## 🔒 Security Implications

Submitters should complete the following questionnaire:

- [ ] This PR adds a new software dependency or dependencies.

- [ ] This PR modifies or invalidates one or more of our security controls.

- [ ] This PR stores or transmits data that was not stored or transmitted before.

- [ ] This PR requires additional review of its security implications for other reasons.

If any of the statements above were checked, then please add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer, and note that this PR should not be merged unless/until he also approves it.
