### PR TITLE
BCDA-7085: Remove unused method GetDbConnection()

### DIFF
--- a/ssas/connection.go
+++ b/ssas/connection.go
@@ -1,7 +1,6 @@
 package ssas
 
 import (
-	"database/sql"
 	"os"
 	"runtime"
 
@@ -13,19 +12,6 @@ import (
 
 // Variable substitution to support testing.
 var LogFatal = log.Fatal
-
-func GetDbConnection() *sql.DB {
-	databaseURL := os.Getenv("DATABASE_URL")
-	db, err := sql.Open("postgres", databaseURL)
-	if err != nil {
-		LogFatal(err)
-	}
-	pingErr := db.Ping()
-	if pingErr != nil {
-		LogFatal(pingErr)
-	}
-	return db
-}
 
 func GetGORMDbConnection() *gorm.DB {
 	databaseURL := os.Getenv("DATABASE_URL")

--- a/ssas/connection_test.go
+++ b/ssas/connection_test.go
@@ -1,7 +1,6 @@
 package ssas
 
 import (
-	"database/sql"
 	"fmt"
 	"os"
 	"testing"
@@ -13,7 +12,6 @@ import (
 
 type ConnectionTestSuite struct {
 	suite.Suite
-	db     *sql.DB
 	gormdb *gorm.DB
 }
 
@@ -35,30 +33,23 @@ func (suite *ConnectionTestSuite) TestDbConnections() {
 	os.Setenv("DATABASE_URL", "fake_db_url")
 
 	// attempt to open DB connection with the bogus DB string
-	suite.db = GetDbConnection()
 	suite.gormdb = GetGORMDbConnection()
 
 	// assert that Ping returns an error
-	assert.Error(suite.T(), suite.db.Ping(), "Database should fail to connect (negative scenario)")
 	db, err := suite.gormdb.DB()
 	assert.NoError(suite.T(), err)
 	assert.Error(suite.T(), db.Ping(), "Gorm database should fail to connect (negative scenario)")
 
 	// close DBs to reset the test
-	_ = suite.db.Close()
 	Close(suite.gormdb)
 
 	// set the database URL back to the real value to test the positive scenarios
 	os.Setenv("DATABASE_URL", actualDatabaseURL)
 
-	suite.db = GetDbConnection()
-	defer suite.db.Close()
-
 	suite.gormdb = GetGORMDbConnection()
 	defer Close(suite.gormdb)
 
 	// assert that Ping() does not return an error
-	assert.Nil(suite.T(), suite.db.Ping(), "Error connecting to sql database")
 	db, err = suite.gormdb.DB()
 	assert.NoError(suite.T(), err)
 	assert.NoError(suite.T(), db.Ping(), "Error connecting to gorm database")


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7085

## 🛠 Changes

- Remove unused method from connection.go

## ℹ️ Context for reviewers

While starting my refactoring for BCDA-7085, I noticed this method is not used in the application. Let's remove it 😄 

## ✅ Acceptance Validation

VSCode shows no references except in the tests.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.