### PR TITLE
BCDA-7116: Add test coverage for Admin API

### DIFF
--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -889,7 +889,7 @@ func (s *APITestSuite) TestDeleteIPIPNotFound() {
 	req := httptest.NewRequest("DELETE", "/system/"+systemID+"/ip/123", nil)
 	rctx := chi.NewRouteContext()
 
-	rctx.URLParams.Add("id", systemID)
+	rctx.URLParams.Add("systemID", systemID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	handler := http.HandlerFunc(deleteSystemIP)
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -241,7 +241,7 @@ func (s *APITestSuite) TestRevokeTokenNoToken() {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// TODO: Handle gracefully
+	// TODO(BCDA-7212): Handle gracefully
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
@@ -1287,7 +1287,7 @@ func (s *APITestSuite) TestCreateV2SystemTokenNonJson() {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// TODO: handle gracefully
+	// TODO(BCDA-7212): Handle gracefully
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
@@ -1419,7 +1419,7 @@ func (s *APITestSuite) TestCreatePublicKeyMissingFields() {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// TODO: Graceful handling of this
+	// TODO(BCDA-7212): Handle gracefully
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -803,19 +803,14 @@ func (s *APITestSuite) TestRegisterSystemIPInvalidBody() {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
+	_ = ssas.CleanDatabase(group)
 }
 
 func (s *APITestSuite) TestRegisterSystemIPSystemNotFound() {
-	group := ssas.Group{GroupID: "test-reset-creds-group"}
-	s.db.Create(&group)
-	system := ssas.System{GID: group.ID, ClientID: "test-reset-creds-client"}
-	s.db.Create(&system)
-
-	systemID := strconv.FormatUint(uint64(system.ID), 10)
 	body := `{"address":"2.5.22.81"}`
 	req := httptest.NewRequest("POST", "/system/123/ip", strings.NewReader(body))
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("systemID", systemID)
+	rctx.URLParams.Add("systemID", "123")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	handler := http.HandlerFunc(registerIP)
 
@@ -901,6 +896,7 @@ func (s *APITestSuite) TestDeleteIPIPNotFound() {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
+	_ = ssas.CleanDatabase(group)
 }
 
 func (s *APITestSuite) TestUpdateSystem() {

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -1173,6 +1173,18 @@ func (s *APITestSuite) TestCreateAndDeleteAdditionalV2SystemToken() {
 	assert.Len(s.T(), system.ClientTokens, 1)
 }
 
+func (s *APITestSuite) TestDeleteV2SystemTokenSystemNotFound() {
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/v2/system/%s/token/%s", "fake-token", "fake-uuid"), strings.NewReader(`{"label":"hello"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("systemID", "fake-token")
+	rctx.URLParams.Add("id", "fake-uuid")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	handler := http.HandlerFunc(deleteToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(s.T(), http.StatusNotFound, rr.Result().StatusCode)
+}
+
 func (s *APITestSuite) TestCreateAndDeletePublicKey() {
 	creds, _ := ssas.CreateTestXDataV2(s.T(), s.db)
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -240,6 +240,8 @@ func (s *APITestSuite) TestRevokeTokenNoToken() {
 	handler := http.HandlerFunc(revokeToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
+	// TODO: Handle gracefully
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
@@ -1239,11 +1241,10 @@ func (s *APITestSuite) TestCreateAndDeleteAdditionalV2SystemToken() {
 	assert.Equal(s.T(), "hello", system.ClientTokens[1].Label)
 
 	//delete the token
-	tokenUUID := system.ClientTokens[1].UUID
-	req = httptest.NewRequest("DELETE", fmt.Sprintf("/v2/system/%s/token/%s", creds.SystemID, tokenUUID), strings.NewReader(`{"label":"hello"}`))
+	req = httptest.NewRequest("DELETE", fmt.Sprintf("/v2/system/%s/token/%s", creds.SystemID, system.ClientTokens[1].UUID), strings.NewReader(`{"label":"hello"}`))
 	rctx = chi.NewRouteContext()
 	rctx.URLParams.Add("systemID", creds.SystemID)
-	rctx.URLParams.Add("id", tokenUUID)
+	rctx.URLParams.Add("id", system.ClientTokens[1].UUID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	handler = deleteToken
 	rr = httptest.NewRecorder()
@@ -1285,6 +1286,8 @@ func (s *APITestSuite) TestCreateV2SystemTokenNonJson() {
 	handler := http.HandlerFunc(createToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
+	// TODO: handle gracefully
 	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 

--- a/ssas/service/admin/api_test.go
+++ b/ssas/service/admin/api_test.go
@@ -880,9 +880,9 @@ func (s *APITestSuite) TestDeleteIPSystemNotFound() {
 }
 
 func (s *APITestSuite) TestDeleteIPIPNotFound() {
-	group := ssas.Group{GroupID: "test-reset-creds-group"}
+	group := ssas.Group{GroupID: "test-delete-ip-ip-not-found-group"}
 	s.db.Create(&group)
-	system := ssas.System{GID: group.ID, ClientID: "test-reset-creds-client"}
+	system := ssas.System{GID: group.ID, ClientID: "test-delete-ip-ip-not-found-client"}
 	s.db.Create(&system)
 
 	systemID := strconv.FormatUint(uint64(system.ID), 10)
@@ -1285,7 +1285,7 @@ func (s *APITestSuite) TestCreateV2SystemTokenNonJson() {
 	handler := http.HandlerFunc(createToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
-	assert.Equal(s.T(), http.StatusBadRequest, rr.Result().StatusCode)
+	assert.Equal(s.T(), http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
 func (s *APITestSuite) TestCreateV2SystemTokenMissingLabel() {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7116

## 🛠 Changes

- Add line coverage where plausible for admin/api.go

## ℹ️ Context for reviewers

The Sonarqube coverage report shows several uncovered lines in this file. Not all lines can be easily covered, but this PR adds tests for specific error cases that are not covered and can be easily covered without changes to the actual application code.

## ✅ Acceptance Validation

- Unit tests pass 😄 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
