### PR TITLE
BCDA-7117: Move systems test utilities to testutils.go

### DIFF
--- a/ssas/systems_test.go
+++ b/ssas/systems_test.go
@@ -668,6 +668,11 @@ func (s *SystemsTestSuite) TestScopeEnvSuccess() {
 	assert.Nil(s.T(), err)
 }
 
+func (s *SystemsTestSuite) TestScopeEnvDebug() {
+	getEnvVars()
+	assert.Equal(s.T(), "bcda-api", DefaultScope)
+}
+
 func (s *SystemsTestSuite) TestScopeEnvFailure() {
 	scope := ""
 	err := os.Setenv("SSAS_DEFAULT_SYSTEM_SCOPE", scope)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7117

## 🛠 Changes

- Move test utilities to testutils.go

## ℹ️ Context for reviewers

Test utilities should not be considered in code coverage metrics and should be moved into the testutils file, which is not included in the metrics.

The other uncovered lines in the systems.go file are not easily testable without major changes to enable mocked database connections (and mocked database errors), so we will need to consider that a potential future effort.

## ✅ Acceptance Validation

- Unit tests pass 😄 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

