### PR TITLE
BCDA-7119: Add test coverage for main SSAS file

### DIFF
--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -140,7 +140,7 @@ func handleFlags(flags Flags) {
 		listExpiringCredentials()
 		return
 	}
-	if flags.doShowXData && (flags.clientID != "" || flags.auth != "") {
+	if flags.doShowXData {
 		if flags.clientID != "" || flags.auth != "" {
 			err := showXData(flags.clientID, flags.auth)
 			if err != nil {
@@ -152,29 +152,24 @@ func handleFlags(flags Flags) {
 		return
 	}
 	if flags.doStart {
-		publicServer, adminServer, forwarder, err := createServers()
-
-		if err != nil {
-			os.Exit(-1)
-		}
-
+		publicServer, adminServer, forwarder := createServers()
 		start(publicServer, adminServer, forwarder)
 		return
 	}
 }
 
-func createServers() (*service.Server, *service.Server, *http.Server, error) {
+func createServers() (*service.Server, *service.Server, *http.Server) {
 	ps := public.Server()
 	if ps == nil {
 		ssas.Logger.Error("unable to create public server")
-		return nil, nil, nil, errors.New("unable to create public server")
+		os.Exit(1)
 	}
 	ps.LogRoutes()
 
 	as := admin.Server()
 	if as == nil {
 		ssas.Logger.Error("unable to create admin server")
-		return nil, nil, nil, errors.New("unable to create admin server")
+		os.Exit(1)
 	}
 	as.LogRoutes()
 
@@ -187,7 +182,7 @@ func createServers() (*service.Server, *service.Server, *http.Server, error) {
 		WriteTimeout:      5 * time.Second,
 	}
 
-	return ps, as, forwarder, nil
+	return ps, as, forwarder
 }
 
 func start(ps *service.Server, as *service.Server, forwarder *http.Server) {

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -162,14 +162,14 @@ func createServers() (*service.Server, *service.Server, *http.Server) {
 	ps := public.Server()
 	if ps == nil {
 		ssas.Logger.Error("unable to create public server")
-		os.Exit(1)
+		os.Exit(-1)
 	}
 	ps.LogRoutes()
 
 	as := admin.Server()
 	if as == nil {
 		ssas.Logger.Error("unable to create admin server")
-		os.Exit(1)
+		os.Exit(-1)
 	}
 	as.LogRoutes()
 

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -52,46 +52,23 @@ import (
 	"gorm.io/gorm"
 )
 
-var doAddFixtureData bool
-var doResetSecret bool
-var doNewAdminSystem bool
-var doListIPs bool
-var doListExpCreds bool
-var doShowXData bool
-var doStart bool
-var clientID string
-var auth string
-var systemName string
+type Flags struct {
+	doAddFixtureData bool
+	doResetSecret    bool
+	doNewAdminSystem bool
+	doListIPs        bool
+	doListExpCreds   bool
+	doShowXData      bool
+	doStart          bool
+	clientID         string
+	auth             string
+	systemName       string
+}
+
 var output io.Writer
 
 func init() {
 	output = os.Stdout
-
-	const usageAddFixtureData = "unconditionally add fixture data"
-	flag.BoolVar(&doAddFixtureData, "add-fixture-data", false, usageAddFixtureData)
-
-	const usageResetSecret = "reset system secret for the given client_id; requires client-id flag with argument"
-	flag.BoolVar(&doResetSecret, "reset-secret", false, usageResetSecret)
-
-	const usageNewAdminSystem = "add a new admin system to the service; requires system-name flag with argument"
-	flag.BoolVar(&doNewAdminSystem, "new-admin-system", false, usageNewAdminSystem)
-	flag.StringVar(&systemName, "system-name", "", "the system's name (e.g., 'BCDA Admin')")
-
-	const usageListIPs = "list all IP addresses registered to active systems"
-	flag.BoolVar(&doListIPs, "list-ips", false, usageListIPs)
-
-	const usageListExpCreds = "list credentials about to expire or timeout due to inactivity"
-	flag.BoolVar(&doListExpCreds, "list-exp-creds", false, usageListExpCreds)
-
-	const usageShowXData = "display group xdata"
-	flag.BoolVar(&doShowXData, "show-xdata", false, usageShowXData)
-	flag.StringVar(&auth, "auth", "", "an auth header containing the hashed client id")
-
-	const usageStart = "start the service"
-	flag.BoolVar(&doStart, "start", false, usageStart)
-
-	// used by both `doResetSecret` and `doGetXdata`
-	flag.StringVar(&clientID, "client-id", "", "a system's client id")
 
 	appName := os.Getenv("NEW_RELIC_APP_NAME")
 	licenseKey := os.Getenv("NEW_RELIC_LICENSE_KEY")
@@ -107,31 +84,65 @@ func init() {
 // We provide some simple commands for bootstrapping the system into place. Commands cannot be combined.
 func main() {
 	ssas.Logger.Info("Home of the System-to-System Authentication Service")
+	var config = parseConfig()
+	handleFlags(config)
+}
 
+func parseConfig() Flags {
+	var flags Flags
+	const usageAddFixtureData = "unconditionally add fixture data"
+	flag.BoolVar(&flags.doAddFixtureData, "add-fixture-data", false, usageAddFixtureData)
+
+	const usageResetSecret = "reset system secret for the given client_id; requires client-id flag with argument"
+	flag.BoolVar(&flags.doResetSecret, "reset-secret", false, usageResetSecret)
+
+	const usageNewAdminSystem = "add a new admin system to the service; requires system-name flag with argument"
+	flag.BoolVar(&flags.doNewAdminSystem, "new-admin-system", false, usageNewAdminSystem)
+	flag.StringVar(&flags.systemName, "system-name", "", "the system's name (e.g., 'BCDA Admin')")
+
+	const usageListIPs = "list all IP addresses registered to active systems"
+	flag.BoolVar(&flags.doListIPs, "list-ips", false, usageListIPs)
+
+	const usageListExpCreds = "list credentials about to expire or timeout due to inactivity"
+	flag.BoolVar(&flags.doListExpCreds, "list-exp-creds", false, usageListExpCreds)
+
+	const usageShowXData = "display group xdata"
+	flag.BoolVar(&flags.doShowXData, "show-xdata", false, usageShowXData)
+	flag.StringVar(&flags.auth, "auth", "", "an auth header containing the hashed client id")
+
+	const usageStart = "start the service"
+	flag.BoolVar(&flags.doStart, "start", false, usageStart)
+
+	// used by both `doResetSecret` and `doGetXdata`
+	flag.StringVar(&flags.clientID, "client-id", "", "a system's client id")
 	flag.Parse()
-	if doAddFixtureData {
+	return flags
+}
+
+func handleFlags(flags Flags) {
+	if flags.doAddFixtureData {
 		addFixtureData()
 		return
 	}
-	if doResetSecret && clientID != "" {
-		resetSecret(clientID)
+	if flags.doResetSecret && flags.clientID != "" {
+		resetSecret(flags.clientID)
 		return
 	}
-	if doNewAdminSystem && systemName != "" {
-		newAdminSystem(systemName)
+	if flags.doNewAdminSystem && flags.systemName != "" {
+		newAdminSystem(flags.systemName)
 		return
 	}
-	if doListIPs {
+	if flags.doListIPs {
 		listIPs()
 		return
 	}
-	if doListExpCreds {
+	if flags.doListExpCreds {
 		listExpiringCredentials()
 		return
 	}
-	if doShowXData && (clientID != "" || auth != "") {
-		if clientID != "" || auth != "" {
-			err := showXData(clientID, auth)
+	if flags.doShowXData && (flags.clientID != "" || flags.auth != "") {
+		if flags.clientID != "" || flags.auth != "" {
+			err := showXData(flags.clientID, flags.auth)
 			if err != nil {
 				ssas.Logger.Error(err)
 			}
@@ -140,7 +151,7 @@ func main() {
 		}
 		return
 	}
-	if doStart {
+	if flags.doStart {
 		start()
 		return
 	}

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -28,19 +28,53 @@ func (s *MainTestSuite) SetupSuite() {
 }
 
 func (s *MainTestSuite) TestResetSecret() {
-	fixtureClientID := "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
-	output := captureOutput(func() { resetSecret(fixtureClientID) })
+	var flags Flags
+	flags.doResetSecret = true
+	flags.clientID = "0c527d2e-2e8a-4808-b11d-0fa06baf8254" // gitleaks:allow
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.NotEqual(s.T(), "", output)
+}
+
+func (s *MainTestSuite) TestResetSecretBadClientID() {
+	var flags Flags
+	flags.doResetSecret = true
+	flags.clientID = "This client does not exist"
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Equal(s.T(), "", output)
 }
 
 func (s *MainTestSuite) TestShowXDataWithClientID() {
 	creds, _ := ssas.CreateTestXData(s.T(), s.db)
 
-	output := captureOutput(func() {
-		err := showXData(creds.ClientID, "")
-		assert.Nil(s.T(), err)
-	})
+	var flags Flags
+	flags.doShowXData = true
+	flags.clientID = creds.ClientID
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.Equal(s.T(), "{\"group\":\"1\"}\n", output)
+}
+
+func (s *MainTestSuite) TestShowXDataClientIDDoesNotExist() {
+	var flags Flags
+	flags.doShowXData = true
+	flags.clientID = "0c527d2e-2e8a-4808-b11d-0fa06baf8123" // gitleaks:allow
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Contains(s.T(), output, "invalid client id")
+}
+
+func (s *MainTestSuite) TestShowXDataSystemGroupIDDoesNotExist() {
+	creds, _ := ssas.CreateTestXData(s.T(), s.db)
+	sys, err := ssas.GetSystemByID(context.Background(), creds.SystemID)
+	assert.Nil(s.T(), err)
+
+	sys.GroupID = ""
+	err = s.db.Save(&sys).Error
+	assert.Nil(s.T(), err)
+
+	var flags Flags
+	flags.doShowXData = true
+	flags.clientID = creds.ClientID
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Contains(s.T(), output, "invalid client id")
 }
 
 func (s *MainTestSuite) TestShowXDataWithAuth() {
@@ -49,32 +83,58 @@ func (s *MainTestSuite) TestShowXDataWithAuth() {
 	// Build encoded api key to mimic auth header
 	auth := base64.StdEncoding.EncodeToString([]byte(creds.ClientID + ":" + creds.ClientSecret))
 
-	output := captureOutput(func() {
-		err := showXData("", auth)
-		assert.Nil(s.T(), err)
-	})
+	var flags Flags
+	flags.doShowXData = true
+	flags.auth = auth
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.Equal(s.T(), "{\"group\":\"1\"}\n", output)
 }
 
-func (s *MainTestSuite) TestResetCredentialsBadClientID() {
-	badClientID := "This client does not exist"
-	output := captureOutput(func() { resetSecret(badClientID) })
-	assert.Equal(s.T(), "", output)
+func (s *MainTestSuite) TestShowXDataWithInvalidBase64() {
+	var flags Flags
+	flags.doShowXData = true
+	flags.auth = "12%123"
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Contains(s.T(), output, "unable to decode the auth hash")
 }
 
-func (s *MainTestSuite) TestMainResetCredentials() {
-	doResetSecret = true
-	clientID = "0c527d2e-2e8a-4808-b11d-0fa06baf8254"
+func (s *MainTestSuite) TestShowXDataWithInvalidAuth() {
+	var flags Flags
+	flags.doShowXData = true
+	flags.auth = "1234"
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Contains(s.T(), output, "no client id present after decoding auth hash")
+}
 
-	output := captureOutput(func() { main() })
+func (s *MainTestSuite) TestShowXDataWithoutParameters() {
+	var flags Flags
+	flags.doShowXData = true
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.Contains(s.T(), output, "requires either the client-id or auth key")
+}
+
+func (s *MainTestSuite) TestAddFixtureData() {
+	var flags Flags
+	flags.doAddFixtureData = true
+
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.NotEqual(s.T(), output, "")
+}
 
-	doResetSecret = false
-	clientID = ""
+func (s *MainTestSuite) TestResetCredentials() {
+	var flags Flags
+	flags.doResetSecret = true
+	flags.clientID = "0c527d2e-2e8a-4808-b11d-0fa06baf8254" // gitleaks:allow
+
+	output := captureOutput(func() { handleFlags(flags) })
+	assert.NotEqual(s.T(), output, "")
 }
 
 func (s *MainTestSuite) TestNewAdminSystem() {
-	output := captureOutput(func() { newAdminSystem("Main Test System") })
+	var flags Flags
+	flags.doNewAdminSystem = true
+	flags.systemName = "Main Test System"
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.NotEqual(s.T(), "", output)
 }
 
@@ -148,7 +208,10 @@ func (s *MainTestSuite) TestListIPs() {
 	var str bytes.Buffer
 	logger := ssas.GetLogger(ssas.Logger)
 	logger.SetOutput(&str)
-	cliOutput := captureOutput(func() { listIPs() })
+
+	var flags Flags
+	flags.doListIPs = true
+	cliOutput := captureOutput(func() { handleFlags(flags) })
 	output := str.String()
 	assert.NotContains(s.T(), output, "unable to get registered IPs")
 	assert.Contains(s.T(), output, testIP)
@@ -171,12 +234,15 @@ func (s *MainTestSuite) TestListExpiringCredentials() {
 	origCreatedAt := secret.CreatedAt
 	origLastTokenAt := system.LastTokenAt
 
+	var flags Flags
+	flags.doListExpCreds = true
+
 	// Credentials that will expire but not timeout during the warning period WILL be shown
 	secret.CreatedAt = time.Now().Add(-84 * 24 * time.Hour)
 	system.LastTokenAt = time.Now().Add(-52 * 24 * time.Hour)
 	assert.Nil(s.T(), db.Save(&system).Error)
 	assert.Nil(s.T(), db.Save(&secret).Error)
-	output := captureOutput(func() { listExpiringCredentials() })
+	output := captureOutput(func() { handleFlags(flags) })
 	assert.NotContains(s.T(), output, "unable")
 	assert.NotContains(s.T(), output, "error")
 	assert.Contains(s.T(), output, fixtureClientID)
@@ -186,7 +252,7 @@ func (s *MainTestSuite) TestListExpiringCredentials() {
 	system.LastTokenAt = time.Now().Add(-54 * 24 * time.Hour)
 	assert.Nil(s.T(), db.Save(&system).Error)
 	assert.Nil(s.T(), db.Save(&secret).Error)
-	output = captureOutput(func() { listExpiringCredentials() })
+	output = captureOutput(func() { handleFlags(flags) })
 	assert.NotContains(s.T(), output, "unable")
 	assert.NotContains(s.T(), output, "error")
 	assert.Contains(s.T(), output, fixtureClientID)
@@ -196,7 +262,7 @@ func (s *MainTestSuite) TestListExpiringCredentials() {
 	system.LastTokenAt = time.Now().Add(-52 * 24 * time.Hour)
 	assert.Nil(s.T(), db.Save(&system).Error)
 	assert.Nil(s.T(), db.Save(&secret).Error)
-	output = captureOutput(func() { listExpiringCredentials() })
+	output = captureOutput(func() { handleFlags(flags) })
 	assert.NotContains(s.T(), output, "unable")
 	assert.NotContains(s.T(), output, "error")
 	assert.NotContains(s.T(), output, fixtureClientID)

--- a/ssas/service/main/main_test.go
+++ b/ssas/service/main/main_test.go
@@ -273,6 +273,16 @@ func (s *MainTestSuite) TestListExpiringCredentials() {
 	assert.Nil(s.T(), db.Save(&secret).Error)
 }
 
+func (s *MainTestSuite) TestCreateServers() {
+	ps, as, forwarder, err := createServers()
+	assert.Nil(s.T(), err)
+
+	start(ps, as, forwarder)
+	ps.Stop()
+	as.Stop()
+	forwarder.Close()
+}
+
 func TestMainTestSuite(t *testing.T) {
 	suite.Run(t, new(MainTestSuite))
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7119

## 🛠 Changes

- Adds testing for the main.go file

## ℹ️ Context for reviewers

This file is the main entrypoint for the program and all related scripts. In order to provide better test coverage over these lines of code, I had to restructure the methods a bit to rely less on global package variables and move most of the main() function into separate, smaller functions that could take in a Flags object.

I also split the start() function so that we could test the "CreateServers" functionality without actually starting web servers. I think we could _probably_ write a test that actually covers starting the web servers and hitting them with HTTP requests but I had some trouble figuring that out, so I left that alone for now. This should still cover a good amount of the file.

## ✅ Acceptance Validation

Unit tests pass.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
