### PR TITLE
BCDA-7416: Remove duplicate logging

### DIFF
--- a/ssas/logger.go
+++ b/ssas/logger.go
@@ -103,6 +103,7 @@ func OperationCalled(data Event) {
 // OperationFailed should be called after an event's failure, and should always be preceded by
 // a call to OperationStarted
 func OperationFailed(data Event) {
+	// *TODO: refactor. Remove OperationFailed to prevent duplicate logging. Address areas affected by removal.
 	mergeNonEmpty(data).WithField("Event", "OperationFailed").Print(data.Help)
 }
 

--- a/ssas/service/api_common.go
+++ b/ssas/service/api_common.go
@@ -26,6 +26,7 @@ func WriteHTTPSError(w http.ResponseWriter, e ssas.ErrorResponse, errorStatus in
 
 // Follow RFC 7591 format for input errors
 func JSONError(w http.ResponseWriter, errorStatus int, statusText string, statusDescription string) {
+	// *TODO: address duplicate logging. Remove logging from JSONError but make sure areas that rely on it for logging, still have logging after removal.
 	e := ssas.ErrorResponse{Error: statusText, ErrorDescription: statusDescription}
 
 	WriteHTTPSError(w, e, errorStatus)

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -1,28 +1,28 @@
 /*
- Package main System-to-System Authentication Service
+	Package main System-to-System Authentication Service
 
- The System-to-System Authentication Service (SSAS) enables one software system to authenticate and authorize another software system. In this model, the Systems act automatically, independent of a human user identity. Human users are involved only to administer the Service, including establishing the identities and privileges of participating systems.
+	The System-to-System Authentication Service (SSAS) enables one software system to authenticate and authorize another software system. In this model, the Systems act automatically, independent of a human user identity. Human users are involved only to administer the Service, including establishing the identities and privileges of participating systems.
 
- For more details see our repository readme and Postman tests:
- - https://github.com/CMSgov/bcda-ssas-app
- - https://github.com/CMSgov/bcda-ssas-app/tree/master/test/postman_test
+	For more details see our repository readme and Postman tests:
+	- https://github.com/CMSgov/bcda-ssas-app
+	- https://github.com/CMSgov/bcda-ssas-app/tree/master/test/postman_test
 
- If you have a Client ID and Secret you can use this page to explore the API.  To do this, click the green "Authorize" button below and enter your Client ID and secret in the Basic Authentication username and password boxes.
+	If you have a Client ID and Secret you can use this page to explore the API.  To do this, click the green "Authorize" button below and enter your Client ID and secret in the Basic Authentication username and password boxes.
 
 Until you click logout your token will be presented with every request made.  To make requests click on the "Try it out" button for the desired endpoint.
 
-     Version: 1.0.0
-     License: Public Domain https://github.com/CMSgov/bcda-ssas-app/blob/master/LICENSE.md
-     Contact: bcapi@cms.hhs.gov
+	    Version: 1.0.0
+	    License: Public Domain https://github.com/CMSgov/bcda-ssas-app/blob/master/LICENSE.md
+	    Contact: bcapi@cms.hhs.gov
 
-     Produces:
-     - application/json
+	    Produces:
+	    - application/json
 
-     SecurityDefinitions:
-     basic_auth:
-          type: basic
+	    SecurityDefinitions:
+	    basic_auth:
+	         type: basic
 
- swagger:meta
+	swagger:meta
 */
 package main
 
@@ -316,7 +316,7 @@ func newAdminSystem(name string) {
 func listIPs() {
 	ips, err := ssas.GetAllIPs()
 	if err != nil {
-		panic("unable to get registered IPs")
+		ssas.Logger.Fatalf("unable to get registered IPs: %s", err)
 	}
 	listOfIps := strings.Join(ips, "\n")
 	fmt.Fprintln(output, listOfIps)

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -1,12 +1,9 @@
 /*
 	Package main System-to-System Authentication Service
-
 	The System-to-System Authentication Service (SSAS) enables one software system to authenticate and authorize another software system. In this model, the Systems act automatically, independent of a human user identity. Human users are involved only to administer the Service, including establishing the identities and privileges of participating systems.
-
 	For more details see our repository readme and Postman tests:
 	- https://github.com/CMSgov/bcda-ssas-app
 	- https://github.com/CMSgov/bcda-ssas-app/tree/master/test/postman_test
-
 	If you have a Client ID and Secret you can use this page to explore the API.  To do this, click the green "Authorize" button below and enter your Client ID and secret in the Basic Authentication username and password boxes.
 
 Until you click logout your token will be presented with every request made.  To make requests click on the "Try it out" button for the desired endpoint.
@@ -14,14 +11,11 @@ Until you click logout your token will be presented with every request made.  To
 	    Version: 1.0.0
 	    License: Public Domain https://github.com/CMSgov/bcda-ssas-app/blob/master/LICENSE.md
 	    Contact: bcapi@cms.hhs.gov
-
 	    Produces:
 	    - application/json
-
 	    SecurityDefinitions:
 	    basic_auth:
 	         type: basic
-
 	swagger:meta
 */
 package main

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -252,6 +252,7 @@ func token(w http.ResponseWriter, r *http.Request) {
 	err = ValidateSecret(system, secret, r)
 	if err != nil {
 		ssas.Logger.Error("The client id and secret cannot be validated: ", err.Error())
+		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "Error getting secret")
 		return
 	}
 

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -296,11 +296,11 @@ func token(w http.ResponseWriter, r *http.Request) {
 func ValidateSecret(system ssas.System, secret string, r *http.Request) (err error) {
 	savedSecret, err := system.GetSecret(r.Context())
 	if !ssas.Hash(savedSecret.Hash).IsHashOf(secret) {
-		err = errors.New(constants.InvalidClientSecret)
+		return errors.New(constants.InvalidClientSecret)
 	}
 
 	if savedSecret.IsExpired() {
-		err = errors.New("The saved client credendials are expired")
+		return errors.New("The saved client credendials are expired")
 	}
 	return err
 }

--- a/ssas/service/public/api.go
+++ b/ssas/service/public/api.go
@@ -252,7 +252,7 @@ func token(w http.ResponseWriter, r *http.Request) {
 	err = ValidateSecret(system, secret, r)
 	if err != nil {
 		ssas.Logger.Error("The client id and secret cannot be validated: ", err.Error())
-		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "Error getting secret")
+		service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), err.Error())
 		return
 	}
 

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -84,6 +84,7 @@ func ChooseSigningKey(signingKeyPath, signingKey string) (*rsa.PrivateKey, error
 
 // NewServer correctly initializes an instance of the Server type.
 func NewServer(name, port, version string, info interface{}, routes *chi.Mux, notSecure bool, useMTLS bool, signingKey *rsa.PrivateKey, ttl time.Duration, clientAssertAud string) *Server {
+
 	if signingKey == nil {
 		ssas.Logger.Error("Private Key is nil")
 		return nil
@@ -160,6 +161,7 @@ func (s *Server) LogRoutes() {
 	routes, err := s.ListRoutes()
 	if err != nil {
 		ssas.Logger.Infof("%s routing error: %v", banner, err)
+		return
 	}
 	ssas.Logger.Infof("%s %v", banner, routes)
 }
@@ -281,6 +283,7 @@ func doHealthCheck(ctx context.Context) bool {
 	}
 
 	if err = db.Ping(); err != nil {
+		// (?) don't know if it actually gets to this error
 		ssas.Logger.Error("health check: database ping error: ", err.Error())
 		return false
 	}

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -160,7 +160,7 @@ func (s *Server) LogRoutes() {
 	banner := fmt.Sprintf("Routes for %s at port %s: ", s.name, s.port)
 	routes, err := s.ListRoutes()
 	if err != nil {
-		ssas.Logger.Infof("%s routing error: %v", banner, err)
+		ssas.Logger.Errorf("%s routing error: %v", banner, err)
 		return
 	}
 	ssas.Logger.Infof("%s %v", banner, routes)
@@ -283,7 +283,6 @@ func doHealthCheck(ctx context.Context) bool {
 	}
 
 	if err = db.Ping(); err != nil {
-		// (?) don't know if it actually gets to this error
 		ssas.Logger.Error("health check: database ping error: ", err.Error())
 		return false
 	}

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -52,7 +52,7 @@ type Server struct {
 func ChooseSigningKey(signingKeyPath, signingKey string) (*rsa.PrivateKey, error) {
 	var key *rsa.PrivateKey = nil
 	var error error = nil
-
+	// *TODO: To prevent duplicate logging, remove error handling out of this function. Return error and log error outside of function.
 	if signingKey == "" && signingKeyPath != "" {
 		sk, err := GetPrivateKey(signingKeyPath)
 		if err != nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7416

## 🛠 Changes

(What was added, updated, or removed in this PR.)
- removes duplicate logging in api.go 
- adds comments for future refactors that would improve logging

## ℹ️ Context for reviewers

(Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.)

- in service/main/main.go > listIPs() : replace panic with ssas.Logger.Fatal
- in server.go > NewServer > ln 164: add return statement after error is logged, so more generic log outside of this condition doesn't log error again. 
- in public/api.go: refactor error logging in ValidateSecret. 
- Adds three "TODOs" to bring attention to potential areas for refactor to streamline logging. TODOs are for the following:
   - Remove logging from JSONError and assert that 130 use cases of this function still have, more specific, logging outside of function 
   - Remove OperationFailed and refactor use cases to use ssas.Logger
   - Refactor ChooseSigningKey so error logging happens outside of function 

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
