### PR TITLE
BCDA hotfix: remove relative path for sourcing .env files

### DIFF
--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"go/build"
 	"io"
 	"net"
 	"os"
@@ -34,18 +33,8 @@ func init() {
 
 func getEnvVars() {
 	env := os.Getenv("DEPLOYMENT_TARGET")
-	gopath := os.Getenv("GOPATH")
 
-	if gopath == "" {
-		gopath = build.Default.GOPATH
-		//when GOROOT==gopath, it'll still be empty. Thus, we specify what's in our Dockerfile.
-		if gopath == "" {
-			gopath = "/go"
-		}
-
-	}
-
-	envPath := fmt.Sprintf(gopath+"/src/github.com/CMSgov/bcda-ssas-app/ssas/cfg/configs/%s.env", env)
+	envPath := fmt.Sprintf("/go/src/github.com/CMSgov/bcda-ssas-app/ssas/cfg/configs/%s.env", env)
 	err := godotenv.Load(envPath)
 
 	if err != nil {


### PR DESCRIPTION
## 🎫 Ticket

No associated ticket

## 🛠 Changes

Removed reliance on gopath for sourcing env file.

## ℹ️ Context for reviewers

Due to some change in the virtual machine configuration where BCDA is deployed, paths no longer aligned in the production environment. This takes the guess-work out of any path work, and uses strictly absolute paths in copying the files in the correct spot. 

## ✅ Acceptance Validation

Building and sourcing now comes from a single directory regardless of configuration (via docker or bare metal).

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
