### PR TITLE
BCDA-8149: Update postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres:11
+    image: postgres:15
     environment:
       - POSTGRES_DB=bcda
       - POSTGRES_PASSWORD=toor


### PR DESCRIPTION
Update postgres to version 15 to correctly mirror what's used in AWS (15.5)

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8149

## 🛠 Changes

Docker compose version for database

## ℹ️ Context

The docker compose version and the one used in AWS weren't matching.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

CI flow passes and versions are updated.
