### PR TITLE
Update docker-compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ package:
 	-v ${PWD}:/go/src/github.com/CMSgov/bcda-ssas-app packaging $(version)
 
 lint:
-	docker compose -f docker compose.test.yml run --rm tests golangci-lint -e SA1029 --timeout 10m0s -v run ./...
-	docker compose -f docker compose.test.yml run --rm tests gosec ./...
+	docker compose -f docker-compose.test.yml run --rm tests golangci-lint -e SA1029 --timeout 10m0s -v run ./...
+	docker compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test-ssas, postman-ssas, and unit-test-ssas
 # Note that these variables should only be used for smoke tests, must be set before the api starts, and cannot be changed after the api starts
@@ -21,17 +21,17 @@ SSAS_ADMIN_CLIENT_ID ?= 31e029ef-0e97-47f8-873c-0e8b7e7f99bf
 SSAS_ADMIN_CLIENT_SECRET := $(shell docker compose run --rm ssas sh -c 'ssas --reset-secret --client-id=$(SSAS_ADMIN_CLIENT_ID)'|tail -n1)
 
 smoke-test:
-	docker compose -f docker compose.test.yml run --rm postman_test test/postman_test/SSAS_Smoke_Test.postman_collection.json -e test/postman_test/local.postman_environment.json --global-var "token=$(token)" --global-var adminClientId=$(SSAS_ADMIN_CLIENT_ID) --global-var adminClientSecret=$(SSAS_ADMIN_CLIENT_SECRET) --global-var ssas_client_assertion_aud=$(SASS_CLIENT_ASSERTION_AUD)
+	docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/SSAS_Smoke_Test.postman_collection.json -e test/postman_test/local.postman_environment.json --global-var "token=$(token)" --global-var adminClientId=$(SSAS_ADMIN_CLIENT_ID) --global-var adminClientSecret=$(SSAS_ADMIN_CLIENT_SECRET) --global-var ssas_client_assertion_aud=$(SASS_CLIENT_ASSERTION_AUD)
 
 postman:
-	docker compose -f docker compose.test.yml run --rm postman_test test/postman_test/SSAS.postman_collection.json -e test/postman_test/local.postman_environment.json --global-var adminClientId=$(SSAS_ADMIN_CLIENT_ID) --global-var adminClientSecret=$(SSAS_ADMIN_CLIENT_SECRET) --global-var ssas_client_assertion_aud=$(SASS_CLIENT_ASSERTION_AUD)
+	docker compose -f docker-compose.test.yml run --rm postman_test test/postman_test/SSAS.postman_collection.json -e test/postman_test/local.postman_environment.json --global-var adminClientId=$(SSAS_ADMIN_CLIENT_ID) --global-var adminClientSecret=$(SSAS_ADMIN_CLIENT_SECRET) --global-var ssas_client_assertion_aud=$(SASS_CLIENT_ASSERTION_AUD)
 
 migrations-test:
-	docker compose -f docker compose.test.yml run --rm tests bash ops/migrations_test.sh
+	docker compose -f docker-compose.test.yml run --rm tests bash ops/migrations_test.sh
 
 unit-test:
 	docker compose up -d db
-	docker compose -f docker compose.test.yml run --rm tests bash unit_test.sh
+	docker compose -f docker-compose.test.yml run --rm tests bash unit_test.sh
 
 test:
 	$(MAKE) lint
@@ -41,12 +41,12 @@ test:
 	$(MAKE) migrations-test
 
 load-fixtures:
-	docker compose -f docker compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations up
-	docker compose -f docker compose.yml run ssas sh -c 'ssas --add-fixture-data'
+	docker compose -f docker-compose.migrate.yml run --rm migrate  -database "postgres://postgres:toor@db:5432/bcda?sslmode=disable" -path /go/src/github.com/CMSgov/bcda-ssas-app/db/migrations up
+	docker compose -f docker-compose.yml run ssas sh -c 'ssas --add-fixture-data'
 
 docker-build:
 	docker compose build --force-rm
-	docker compose -f docker compose.test.yml build --force-rm
+	docker compose -f docker-compose.test.yml build --force-rm
 
 docker-bootstrap:
 	$(MAKE) docker-build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Imports always go up the directory tree from leaves; that is, parents do not imp
 
 Values below are either indicated by Required, SSAS, BCDA, or a combination.
 
-- Required values must be present in the docker-compose.\*.yml files.
+- Required values must be present in the docker compose.\*.yml files.
 - Some values are primarily for the use of the BCDA API, and are only used by SSAS for testing purposes.
 - Some values are only used by the BCDA API; they are listed for reference.
 
@@ -104,7 +104,7 @@ The project uses [Go Modules](https://golang.org/ref/mod) allowing you to clone 
 
 # Build
 
-Build all the code and containers with `make docker-bootstrap`. Alternatively, `docker-compose up ssas` will build and run the SSAS by itself. Note that SSAS needs the db container to be running as well.
+Build all the code and containers with `make docker-bootstrap`. Alternatively, `docker compose up ssas` will build and run the SSAS by itself. Note that SSAS needs the db container to be running as well.
 
 ## Bootstrapping CLI
 
@@ -129,7 +129,7 @@ one of these test suites, follow the instructions at the top of the test file.
 
 ### **Running Single / Single-file Unit Tests**
 
-This step assumes that the user has installed VSCode, the Go language extension available [here](https://marketplace.visualstudio.com/items?itemName=golang.Go), and has successfully imported test data to their local database. 
+This step assumes that the user has installed VSCode, the Go language extension available [here](https://marketplace.visualstudio.com/items?itemName=golang.Go), and has successfully imported test data to their local database.
 
 To run tests from within VSCode:
 In a FILENAME_test.go file, there will be a green arrow to the left of the method name, and clicking this arrow will run a single test locally. Tests should not be dependent upon other tests, but if a known-good test is failing, the user can run all tests in a given file by going to View -> Command Palette -> Go: Test Package, which will run all tests in a given file. Alternatively, in some instances, the init() method can be commented out to enable testing of single functions.
@@ -138,13 +138,13 @@ In a FILENAME_test.go file, there will be a green arrow to the left of the metho
 
 To run postman tests locally:
 
-Build and startup the required containers. Building with docker-compose up first will significantly improve the performance of the following steps.
+Build and startup the required containers. Building with docker compose up first will significantly improve the performance of the following steps.
 
 ```
-docker-compose up
-docker-compose stop
-docker-compose up -d db
-docker-compose up ssas
+docker compose up
+docker compose stop
+docker compose up -d db
+docker compose up ssas
 ```
 
 If this is the first time you've started the containers, set up your database tables and seed them with sample group and systems:
@@ -175,13 +175,13 @@ docker run --rm --network bcda-ssas-app_default -e PGPASSWORD=PASSHERE -it postg
 To reset a secret by client id (can be found in Makefile):
 
 ```
-docker-compose run --rm ssas sh -c 'ssas --reset-secret --client-id=[client_id]'
+docker compose run --rm ssas sh -c 'ssas --reset-secret --client-id=[client_id]'
 ```
 
 To list all active IPs from the connected database:
 
 ```
-docker-compose run --rm ssas sh -c 'ssas --list-ips'
+docker compose run --rm ssas sh -c 'ssas --list-ips'
 ```
 
 # Swagger Documentation
@@ -190,11 +190,11 @@ The admin server has Swagger documentation. To access:
 
 1. Make sure it's been built (the container will stop after a few seconds when the documentation is ready)
 
-   `docker-compose up documentation`
+   `docker compose up documentation`
 
 1. Make sure the `ssas` container is running
 
-   `docker-compose up ssas`
+   `docker compose up ssas`
 
 1. Access Swagger in your browser:
    http://localhost:3104/swagger

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Imports always go up the directory tree from leaves; that is, parents do not imp
 
 Values below are either indicated by Required, SSAS, BCDA, or a combination.
 
-- Required values must be present in the docker compose.\*.yml files.
+- Required values must be present in the docker-compose.\*.yml files.
 - Some values are primarily for the use of the BCDA API, and are only used by SSAS for testing purposes.
 - Some values are only used by the BCDA API; they are listed for reference.
 

--- a/ops/migrations_test.sh
+++ b/ops/migrations_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script is intended to be run from within the Docker "tests" container
-# The docker-compose file brings forward the env vars: DB
+# The docker compose file brings forward the env vars: DB
 #
 set -e
 set -o pipefail

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script is intended to be run from within the Docker "unit_test" container
-# The docker-compose file brings forward the env vars: DB
+# The docker compose file brings forward the env vars: DB
 #
 set -e
 set -o pipefail


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Did a find-replace for `docker-compose ` to `docker compose `

## ℹ️ Context

See https://github.com/orgs/community/discussions/116610 for relevant discussion.

## 🧪 Validation

See PR checks and [this deployment](https://management.bcda.cms.gov/job/BCDA%20-%20Build%20and%20Package/4316/) which uses the kev/ci branch across our app and ops repos.