### PR TITLE
PLT-639: Adding gitleaks MBI scanning & updating gitleaks pre-commit version

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out
@@ -46,7 +46,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Download code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage-report
       - name: Set env vars from AWS params

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+title = "DASG Standard"
+
+[extend]
+  useDefault = true
+
+[[rules]]
+  id = "mbi-detection"
+  description = "Detects a potential MBI pattern based on https://www.cms.gov/medicare/new-medicare-card/understanding-the-mbi.pdf"
+  regex = '''\b((?i)[1-9][ACDEFGHJKMNPQRTUVWXY][ACDEFGHJKMNPQRTUVWXY\d]-?\d[ACDEFGHJKMNPQRTUVWXY][ACDEFGHJKMNPQRTUVWXY\d]\d-?[ACDEFGHJKMNPQRTUVWXY]{2}\d{2})\b'''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
+    rev: v8.19.2
     hooks:
       - id: gitleaks
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: master
+    rev: v1.0.0-rc.1
     hooks:
       - id: go-imports
         args: ['-w']


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

Gitleaks custom config extension was added (.gitleaks.toml) allowing for a regex-based MBI filter to be run against new commits, and the gitleaks pre-commit version was updated to 8.19.x which doesn't affect us at this time.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

Bulk API Platform Team has an ongoing goal of improving security and safeguarding PHI/PII for our members, to that end we are applying a belt-and-suspenders approach to preventing leakage of data (such as Medicare Beneficiary Identifiers) in github.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

##   Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

These changes were tested locally and automatically as they make modifications to the pre-commit functionality, and were initially tested and validated against a pregenerated file with MBI data in PLT-532.
