### PR TITLE
Fix calls to fmt Errorf with no interpolation

### DIFF
--- a/ssas/groups.go
+++ b/ssas/groups.go
@@ -106,8 +106,7 @@ func ListGroups(ctx context.Context) (list GroupList, err error) {
 func UpdateGroup(ctx context.Context, id string, gd GroupData) (Group, error) {
 	g, err := GetGroupByID(ctx, id)
 	if err != nil {
-		errString := fmt.Sprintf("record not found for id=%s", id)
-		err := fmt.Errorf(errString)
+		err := fmt.Errorf("record not found for id=%s", id)
 		return Group{}, err
 	}
 	gd.GroupID = g.Data.GroupID

--- a/ssas/service/server.go
+++ b/ssas/service/server.go
@@ -58,7 +58,7 @@ func ChooseSigningKey(signingKeyPath, signingKey string) (*rsa.PrivateKey, error
 		if err != nil {
 			msg := fmt.Sprintf("bad signing key; path %s; %v", signingKeyPath, err)
 			ssas.Logger.Error(msg)
-			error = fmt.Errorf(msg)
+			error = errors.New(msg)
 		}
 		key = sk
 	} else if signingKey != "" && signingKeyPath == "" {
@@ -66,17 +66,17 @@ func ChooseSigningKey(signingKeyPath, signingKey string) (*rsa.PrivateKey, error
 		if err != nil {
 			msg := fmt.Sprintf("bad inline signing key; %v", err)
 			ssas.Logger.Error(msg)
-			error = fmt.Errorf(msg)
+			error = errors.New(msg)
 		}
 		key = sk
 	} else if signingKey == "" && signingKeyPath == "" {
 		msg := "inline key and path are both empty strings"
 		ssas.Logger.Error(msg)
-		error = fmt.Errorf(msg)
+		error = errors.New(msg)
 	} else {
 		msg := "inline key or path must be set, but not both"
 		ssas.Logger.Error(msg)
-		error = fmt.Errorf(msg)
+		error = errors.New(msg)
 	}
 
 	return key, error
@@ -481,7 +481,7 @@ func (s *Server) CheckRequiredClaims(claims *CommonClaims, requiredTokenType str
 	}
 
 	if requiredTokenType != claims.TokenType {
-		return fmt.Errorf(fmt.Sprintf("wrong token type: %s; required type: %s", claims.TokenType, requiredTokenType))
+		return fmt.Errorf("wrong token type: %s; required type: %s", claims.TokenType, requiredTokenType)
 	}
 	return nil
 }

--- a/ssas/service/tokenblacklist.go
+++ b/ssas/service/tokenblacklist.go
@@ -70,7 +70,7 @@ func (t *Blacklist) BlacklistToken(ctx context.Context, tokenID string, blacklis
 	entryDate := time.Now()
 	expirationDate := entryDate.Add(blacklistExpiration)
 	if _, err := ssas.CreateBlacklistEntry(ctx, tokenID, entryDate, expirationDate); err != nil {
-		return fmt.Errorf(fmt.Sprintf("unable to blacklist token id %s: %s", tokenID, err.Error()))
+		return fmt.Errorf("unable to blacklist token id %s: %s", tokenID, err.Error())
 	}
 
 	// Add to cache only after token is blacklisted in database

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -238,7 +238,7 @@ func (system *System) RevokeSecret(ctx context.Context, systemID string) error {
 
 	err = system.deactivateSecrets(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to revoke credentials for clientID " + system.ClientID)
+		return fmt.Errorf("unable to revoke credentials for clientID %s", system.ClientID)
 	}
 	return nil
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8373

## 🛠 Changes

Convert various fmt.Errorf statements to either require the interpolation or to errors.New.  Both versions should return a string as an error.

## ℹ️ Context

The build was failing on golangci-lint checks.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Linting and testing were run to verify no breaking changes.
