### PR TITLE
BCDA-8570 Upgrade github action artifact to v4

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: ./test_results/latest/testcoverage.out
@@ -41,12 +41,9 @@ jobs:
     name: Sonarqube Quality Gate
     needs: build
     runs-on: self-hosted
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Download code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
       - name: Set env vars from AWS params


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8570

## 🛠 Changes

Upgraded github actions artifact-(up|down)load to v4.

## ℹ️ Context

v3 was deprecated as of Nov 30th.  We were previously prevented upgrading to v4 due to dependencies on node.  PLT-338 fixed that for us and has since been deployed.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Github actions workflows successfully passing as normal.
