### PR TITLE
Set docker test image to old version, fix linting issue

### DIFF
--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM golang:alpine3.20
+FROM golang:1.23.6-alpine3.20
 
 RUN apk update upgrade
 

--- a/lambda/wafsync/main.go
+++ b/lambda/wafsync/main.go
@@ -43,10 +43,6 @@ func handler(ctx context.Context, event events.S3Event) ([]string, error) {
 	defer conn.Close(ctx)
 
 	sess := session.Must(session.NewSession())
-	if err != nil {
-		log.Errorf("Failed creating session to update ip set, %+v", err)
-		return nil, err
-	}
 	wafsvc := wafv2.New(sess, &aws.Config{
 		Region: aws.String("us-east-1"),
 	})


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8764

## 🛠 Changes

Set docker tests image version to older version, as it was breaking test suite.

## ℹ️ Context

SSAS build/deploy was breaking due to this, which was also breaking BCDA deploys.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing and linting.
