### PR TITLE
[PLT-916] Remove manual docker-compose install

### DIFF
--- a/.github/workflows/package-rpm.yml
+++ b/.github/workflows/package-rpm.yml
@@ -23,13 +23,6 @@ jobs:
     name: Package BCDA SSAS
     runs-on: self-hosted
     steps:
-      # TODO: TEMP (can remove this step once PLT-905 is implemented)
-      - name: Install docker compose manually
-        run: |
-          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
       - name: Checkout SSAS
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-916

## 🛠 Changes

Removed obsolete docker-compose install.  No longer needed after completion of PLT-905.

## ℹ️ Context

Changes made as part of PLT-916, upgrade gold ami to AL2023

## 🧪 Validation
Deployed to dev and test.  Smoke tests passed and manual validation passed.
