### PR TITLE
BCDA-9145: temporarily create two ci-checks workflows

### DIFF
--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -1,13 +1,7 @@
-name: CI Checks
+name: CI Checks (Pull Request)
 
 on:
-  # push:
-  # workflow_call:
-  #   inputs:
-  #     ssas_release_version:
-  #       description: 'Release version (or branch name)'
-  #       required: true
-  #       type: string
+  push:
   workflow_dispatch:
     inputs:
       ssas_release_version:
@@ -21,7 +15,7 @@ env:
 jobs:
   go_mod_tidy:
     name: Modules Lint
-    runs-on: codebuild-bcda-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9145

## 🛠 Changes

Create two versions of ci-checks: one for PRs and one for workflow calls from the bcda-app repository.
This is a temporary measure until we can give access to ssas codebuild runners from bcda-app.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
