### PR TITLE
BCDA-9225: reconfigure golang linting

### DIFF
--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version-file: 'go.mod'
       - name: Tidy modules
         run: |
           go mod tidy -v
@@ -48,7 +48,7 @@ jobs:
       - name: Get Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version-file: 'go.mod'
       - name: Install docker compose manually
         run: |
           sudo mkdir -p /usr/local/lib/docker/cli-plugins

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version-file: 'go.mod'
       - name: Tidy modules
         run: |
           go mod tidy -v
@@ -54,7 +54,7 @@ jobs:
       - name: Get Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version-file: 'go.mod'
       - name: Install docker compose manually
         run: |
           sudo mkdir -p /usr/local/lib/docker/cli-plugins

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Get Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.6'
+          go-version-file: 'go.mod'
       - name: Get golang-migrate
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Migrate DB

--- a/.github/workflows/waf-sync-lambda-deploy.yml
+++ b/.github/workflows/waf-sync-lambda-deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-            go-version: '1.23.1'
+          go-version-file: 'go.mod'
       - name: Build WAF Sync Lambda zip file
         env:
           CGO_ENABLED: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
     rev: v2.2.1
     hooks:
       - id: golangci-lint
-        args: ['--new', '-v', '--fast-only']
+        args: ['-v']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: v8.19.2
     hooks:
       - id: gitleaks
-  - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.2.1
     hooks:
-      - id: go-imports
-        args: ['-w']
+      - id: golangci-lint
+        args: ['--new', '-v', '--fast-only']

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -4,7 +4,7 @@ RUN apk update upgrade
 
 RUN apk add bash build-base curl
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.2.1
 
 RUN GO111MODULE=on go install github.com/xo/usql@v0.17.5
 RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.20.0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ package:
 
 # -D(isabling) errcheck and staticcheck linters for now due to v2 upgrade, see: https://jira.cms.gov/browse/BCDA-8911
 lint:
-	docker compose -f docker-compose.test.yml run --rm tests golangci-lint --timeout 10m0s -v run ./...
+	docker compose -f docker-compose.test.yml run --rm tests golangci-lint --timeout 10m0s -v run --new-from-merge-base=main
 	docker compose -f docker-compose.test.yml run --rm tests gosec ./...
 
 # The following vars are available to tests needing SSAS admin credentials; currently they are used in smoke-test-ssas, postman-ssas, and unit-test-ssas


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9225

## 🛠 Changes

- configured the standard golangci-lint pre-commit hook to replace the wrapper hook we had been using before
- set predefined versions for our linters that we can update ourselves (this version management may change when we upgrade to go 1.24)
- updated configuration of ci linter to specifically lint the changes that are different from main
- configured setup-go job to fetch the go version from go.mod in all workflows

## ℹ️ Context

These changes mirror changes made to bcda-app [here](https://github.com/CMSgov/bcda-app/pull/1155)

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

1. create a new branch from this branch
2. make an update to any go file with a linting error. when you try to commit, the pre-commit hook should catch the error and not raise a bunch of false positives
3. commit the error from step 2 with go commit --no-verify and push the branch. verify that the ci-checks workflow catches the error
