### PR TITLE
BCDA-8921: Add SGA key to admin endpoints middleware

### DIFF
--- a/ssas/constants/constants.go
+++ b/ssas/constants/constants.go
@@ -14,3 +14,7 @@ const TokenEndpoint = "/token"
 const HeaderApplicationJSON = "application/json"
 
 const Application = "ssas"
+
+type CtxSGAKeyType string
+
+const CtxSGAKey CtxSGAKeyType = "CtxSGAKey"

--- a/ssas/service/admin/middleware.go
+++ b/ssas/service/admin/middleware.go
@@ -1,9 +1,12 @@
 package admin
 
 import (
+	"context"
 	"net/http"
+	"os"
 
 	"github.com/CMSgov/bcda-ssas-app/ssas"
+	"github.com/CMSgov/bcda-ssas-app/ssas/constants"
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 )
 
@@ -19,6 +22,10 @@ func requireBasicAuth(next http.Handler) http.Handler {
 		if err != nil {
 			service.JSONError(w, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), "invalid client id")
 			return
+		}
+
+		if os.Getenv("SGA_ADMIN_FEATURE") == "true" {
+			r = r.WithContext(context.WithValue(r.Context(), constants.CtxSGAKey, system.SGAKey))
 		}
 
 		savedSecret, err := system.GetSecret(r.Context())

--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -54,6 +54,7 @@ func routes() *chi.Mux {
 	m := monitoring.GetMonitor()
 
 	r.Use(gcmw.RequestID, service.GetTransactionID, service.NewAPILogger(), service.ConnectionClose, service.NewCtxLogger)
+
 	r.With(requireBasicAuth).Post(m.WrapHandler("/group", createGroup))
 	r.With(requireBasicAuth).Get(m.WrapHandler("/group", listGroups))
 	r.With(requireBasicAuth).Put(m.WrapHandler("/group/{id}", updateGroup))
@@ -78,7 +79,6 @@ func routes() *chi.Mux {
 		r.With(requireBasicAuth).Delete(m.WrapHandler("/system/{systemID}/token/{id}", deleteToken))
 		r.With(requireBasicAuth).Post(m.WrapHandler("/system/{systemID}/key", createKey))
 		r.With(requireBasicAuth).Delete(m.WrapHandler("/system/{systemID}/key/{id}", deleteKey))
-
 	})
 
 	swaggerPath := "./swaggerui"

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -221,13 +221,16 @@ func addFixtureData() {
 	makeSystem(db, "admin", "31e029ef-0e97-47f8-873c-0e8b7e7f99bf",
 		"BCDA API Admin", "bcda-admin",
 		"ofSsVmNaR6+nq93pGUhzKcLvJlokzE4mKqBxS8kt5Fc=:yt+N0wLzqZsY4Lw0pIEWlySbU7y7P7mNnn8IUjsZR0qis9/X2aKtjAMKlFRcCp+CYDeF/+FrvzuCDqacQwX+hA==:130000",
+		"bcda",
 	)
 	makeSystem(db, "0c527d2e-2e8a-4808-b11d-0fa06baf8254",
 		"0c527d2e-2e8a-4808-b11d-0fa06baf8254", "ACO Dev", "bcda-api",
-		"bUtFIoldpvBjK92JoJrZEQCZbjTAI0o5RRJ+krdHMFA=:iKOi8/rskQ+ykmA32f3iVNQ6SWBJbWrC0weq7K6R1LF164zKcmQ8PXa4CMUZ1kd8sBBqvP+ISTYqwDu9C+5dtA==:130000")
+		"bUtFIoldpvBjK92JoJrZEQCZbjTAI0o5RRJ+krdHMFA=:iKOi8/rskQ+ykmA32f3iVNQ6SWBJbWrC0weq7K6R1LF164zKcmQ8PXa4CMUZ1kd8sBBqvP+ISTYqwDu9C+5dtA==:130000",
+		"bcda",
+	)
 }
 
-func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) {
+func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash, sgaKey string) {
 	pem := `-----BEGIN PUBLIC KEY-----
 	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhxobShmNifzW3xznB+L
 	I8+hgaePpSGIFCtFz2IXGU6EMLdeufhADaGPLft9xjwdN1ts276iXQiaChKPA2CK
@@ -243,7 +246,7 @@ func makeSystem(db *gorm.DB, groupID, clientID, clientName, scope, hash string) 
 		ssas.Logger.Warn(err)
 	}
 
-	system := ssas.System{GID: g.ID, GroupID: groupID, ClientID: clientID, ClientName: clientName, APIScope: scope}
+	system := ssas.System{GID: g.ID, GroupID: groupID, ClientID: clientID, ClientName: clientName, APIScope: scope, SGAKey: sgaKey}
 	if err := db.Save(&system).Error; err != nil {
 		ssas.Logger.Warn(err)
 	}

--- a/ssas/systems.go
+++ b/ssas/systems.go
@@ -78,6 +78,7 @@ type System struct {
 	Secrets        []Secret        `json:"secrets,omitempty"`
 	LastTokenAt    time.Time       `json:"last_token_at"`
 	XData          string          `json:"xdata"`
+	SGAKey         string          `json:"sga_key"`
 }
 
 type EncryptionKey struct {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8921

## 🛠 Changes

Add SGA key to systems model, fixtures, etc.
Add SGA key into context for all admin endpoint requests.

## ℹ️ Context

To help prepare work related around better admin permissioning in SSAS.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing.
