### PR TITLE
BCDA-9375: Minor cleanup for WAF sync lambda

### DIFF
--- a/lambda/wafsync/main.go
+++ b/lambda/wafsync/main.go
@@ -21,7 +21,7 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event events.S3Event) ([]string, error) {
+func handler(ctx context.Context, event events.S3Event) error {
 	log.Info("Starting WAF Sync Lambda")
 
 	log.SetFormatter(&log.JSONFormatter{
@@ -32,13 +32,13 @@ func handler(ctx context.Context, event events.S3Event) ([]string, error) {
 	dbURL, err := getDBURL()
 	if err != nil {
 		log.Errorf("Unable to extract DB URL from parameter store: %+v", err)
-		return nil, err
+		return err
 	}
 
 	conn, err := pgx.Connect(ctx, dbURL)
 	if err != nil {
 		log.Errorf("Unable to connect to database: %+v", err)
-		return nil, err
+		return err
 	}
 	defer conn.Close(ctx)
 
@@ -47,14 +47,14 @@ func handler(ctx context.Context, event events.S3Event) ([]string, error) {
 		Region: aws.String("us-east-1"),
 	})
 
-	addrs, err := updateIpSet(ctx, conn, wafsvc)
+	_, err = updateIpSet(ctx, conn, wafsvc)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	log.Info("Completed WAF Sync lambda")
 
-	return addrs, nil
+	return nil
 }
 
 func updateIpSet(ctx context.Context, conn PgxConnection, wafsvc wafv2iface.WAFV2API) ([]string, error) {
@@ -85,6 +85,10 @@ func updateIpSet(ctx context.Context, conn PgxConnection, wafsvc wafv2iface.WAFV
 	var addresses []string
 	addresses = append(addresses, ipv4Addrs...)
 	addresses = append(addresses, ipv6Addrs...)
+
+	if len(addresses) == 0 {
+		log.WithField("name", ipSetName).Warn("length of IP addresses to update is 0, potentially problematic")
+	}
 
 	return addresses, nil
 }

--- a/lambda/wafsync/main.go
+++ b/lambda/wafsync/main.go
@@ -87,7 +87,7 @@ func updateIpSet(ctx context.Context, conn PgxConnection, wafsvc wafv2iface.WAFV
 	addresses = append(addresses, ipv6Addrs...)
 
 	if len(addresses) == 0 {
-		log.WithField("name", ipSetName).Warn("length of IP addresses to update is 0, potentially problematic")
+		log.WithField("name", ipSetName).Error("length of IP addresses to update is 0, potentially problematic")
 	}
 
 	return addresses, nil


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9375

## 🛠 Changes

Two minor changes:
- Dont log IP addresses (not useful)
- Alert if updated IP addresses is ever empty (could potentially be an issue)

## ℹ️ Context

With the recent incident with WAF Sync lambda we had some thoughts on updating WAF sync lambda in various ways.  This is just a small part of that cleanup.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local testing, workflow integration testing.
