### PR TITLE
BCDA-9445: Remove init in admin/public router.go

### DIFF
--- a/ssas/service/admin/router.go
+++ b/ssas/service/admin/router.go
@@ -17,21 +17,14 @@ import (
 	"github.com/CMSgov/bcda-ssas-app/ssas/service"
 )
 
-var infoMap map[string][]string
-var adminSigningKeyPath string
-var adminSigningKey string
-var server *service.Server
-
-func init() {
-	infoMap = make(map[string][]string)
-	adminSigningKeyPath = os.Getenv("SSAS_ADMIN_SIGNING_KEY_PATH")
-	adminSigningKey = os.Getenv("SSAS_ADMIN_SIGNING_KEY")
-}
-
 // Server creates an SSAS admin server
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
 	useMTLS := os.Getenv("ADMIN_USE_MTLS") == "true"
+	adminSigningKeyPath := os.Getenv("SSAS_ADMIN_SIGNING_KEY_PATH")
+	adminSigningKey := os.Getenv("SSAS_ADMIN_SIGNING_KEY")
+
+	infoMap := make(map[string][]string)
 
 	signingKey, err := service.ChooseSigningKey(adminSigningKeyPath, adminSigningKey)
 	if err != nil {
@@ -40,7 +33,7 @@ func Server() *service.Server {
 		return nil
 	}
 
-	server = service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, useMTLS, signingKey, 20*time.Minute, "")
+	server := service.NewServer("admin", ":3004", constants.Version, infoMap, routes(), unsafeMode, useMTLS, signingKey, 20*time.Minute, "")
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "admin", ":3004")}

--- a/ssas/service/public/router.go
+++ b/ssas/service/public/router.go
@@ -13,25 +13,15 @@ import (
 	gcmw "github.com/go-chi/chi/v5/middleware"
 )
 
-var infoMap map[string][]string
-var publicSigningKeyPath string
-var publicSigningKey string
-var clientAssertAud string
-
-var server *service.Server
-
-func init() {
-	infoMap = make(map[string][]string)
-	publicSigningKeyPath = os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
-	publicSigningKey = os.Getenv("SSAS_PUBLIC_SIGNING_KEY")
-	ssas.Logger.Info("public signing key sourced from ", publicSigningKeyPath)
-	clientAssertAud = os.Getenv("SSAS_CLIENT_ASSERTION_AUD")
-	ssas.Logger.Info("aud value required in client assertion tokens:", clientAssertAud)
-}
-
 func Server() *service.Server {
 	unsafeMode := os.Getenv("HTTP_ONLY") == "true"
 	useMTLS := os.Getenv("PUBLIC_USE_MTLS") == "true"
+	infoMap := make(map[string][]string)
+	publicSigningKeyPath := os.Getenv("SSAS_PUBLIC_SIGNING_KEY_PATH")
+	publicSigningKey := os.Getenv("SSAS_PUBLIC_SIGNING_KEY")
+	ssas.Logger.Info("public signing key sourced from ", publicSigningKeyPath)
+	clientAssertAud := os.Getenv("SSAS_CLIENT_ASSERTION_AUD")
+	ssas.Logger.Info("aud value required in client assertion tokens:", clientAssertAud)
 
 	signingKey, err := service.ChooseSigningKey(publicSigningKeyPath, publicSigningKey)
 	if err != nil {
@@ -40,7 +30,7 @@ func Server() *service.Server {
 		return nil
 	}
 
-	server = service.NewServer("public", ":3003", constants.Version, infoMap, routes(), unsafeMode, useMTLS, signingKey, 20*time.Minute, clientAssertAud)
+	server := service.NewServer("public", ":3003", constants.Version, infoMap, routes(), unsafeMode, useMTLS, signingKey, 20*time.Minute, clientAssertAud)
 	if server != nil {
 		r, _ := server.ListRoutes()
 		infoMap["banner"] = []string{fmt.Sprintf("%s server running on port %s", "public", ":3003")}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9445

## 🛠 Changes

Removed init in admin/router.go and public/router.go files. Environment variables from those init statements are now sourced during server setup, which happens on application startup.

## ℹ️ Context

Removing init as part of effort to improve test suite and reduce effort to add new and maintain existing tests.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

tests passing with changes.
