### PR TITLE
BCDA-9505: remove tokens.go init

### DIFF
--- a/ssas/cfg/config.go
+++ b/ssas/cfg/config.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	DefaultScope         string
-	MaxIPs               int
-	CredentialExpiration time.Duration
-	MacaroonExpiration   time.Duration
-	HashIter             int
-	HashKeyLen           int
-	SaltSize             int
+	DefaultScope                  string
+	MaxIPs                        int
+	CredentialExpiration          time.Duration
+	MacaroonExpiration            time.Duration
+	HashIter                      int
+	HashKeyLen                    int
+	SaltSize                      int
+	SelfRegistrationTokenDuration time.Duration
 )
 
 // Get configuration/environment variables for Hashes and Systems.
@@ -67,4 +68,7 @@ func LoadEnvConfigs() {
 		// ServiceHalted(Event{Help:"SSAS_HASH_ITERATIONS, SSAS_HASH_KEY_LENGTH and SSAS_HASH_SALT_SIZE environment values must be set"})
 		panic("SSAS_HASH_ITERATIONS, SSAS_HASH_KEY_LENGTH and SSAS_HASH_SALT_SIZE environment values must be set")
 	}
+
+	minutes := GetEnvInt("SSAS_MFA_TOKEN_TIMEOUT_MINUTES", 60)
+	SelfRegistrationTokenDuration = time.Duration(int64(time.Minute) * int64(minutes))
 }

--- a/ssas/service/main/main.go
+++ b/ssas/service/main/main.go
@@ -90,6 +90,7 @@ func main() {
 	var config = parseFlags()
 	NewNewRelicApp()
 	cfg.LoadEnvConfigs()
+	public.SetAccessTokenCreator()
 	handleFlags(config)
 }
 

--- a/ssas/service/public/api_test.go
+++ b/ssas/service/public/api_test.go
@@ -53,6 +53,7 @@ func (s *APITestSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 	cfg.LoadEnvConfigs()
 	s.h = NewPublicHandler()
+	SetAccessTokenCreator()
 	s.server = Server()
 	s.badSigningKeyPath = "../../../shared_files/ssas/admin_test_signing_key.pem"
 	s.assertAud = "http://local.testing.cms.gov/api/v2/Token/auth"

--- a/ssas/service/public/tokens.go
+++ b/ssas/service/public/tokens.go
@@ -3,7 +3,6 @@ package public
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/CMSgov/bcda-ssas-app/ssas"
 	"github.com/CMSgov/bcda-ssas-app/ssas/cfg"
@@ -13,12 +12,7 @@ import (
 
 var accessTokenCreator TokenCreator
 
-var selfRegistrationTokenDuration time.Duration
-
-func init() {
-	minutes := cfg.GetEnvInt("SSAS_MFA_TOKEN_TIMEOUT_MINUTES", 60)
-	selfRegistrationTokenDuration = time.Duration(int64(time.Minute) * int64(minutes))
-
+func SetAccessTokenCreator() {
 	accessTokenCreator = AccessTokenCreator{}
 }
 
@@ -33,10 +27,6 @@ func GetAccessTokenCreator() TokenCreator {
 // then add CreateCommonClaims to this interface that all 3 can share.
 type TokenCreator interface {
 	GenerateToken(claims service.CommonClaims) (*jwt.Token, string, error)
-}
-
-// AccessTokenCreator is an implementation of TokenCreator that creates access tokens.
-type AccessTokenCreator struct {
 }
 
 // validates that AccessTokenCreator implements the TokenCreator interface
@@ -54,7 +44,11 @@ func MintRegistrationToken(oktaID string, groupIDs []string) (*jwt.Token, string
 		return nil, "", err
 	}
 
-	return server.MintTokenWithDuration(&claims, selfRegistrationTokenDuration)
+	return server.MintTokenWithDuration(&claims, cfg.SelfRegistrationTokenDuration)
+}
+
+// AccessTokenCreator is an implementation of TokenCreator that creates access tokens.
+type AccessTokenCreator struct {
 }
 
 // GenerateToken generates a tokenstring that expires in server.tokenTTL time


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9505

## 🛠 Changes

remove init in tokens.go; initializing needed variables in config package. Moved init to function `SetAccessTokenCreator` that is called in main. 

## ℹ️ Context

Changes were made as larger initiative to remove init in the codebase. Init has been a development slowdown and blocker when troubleshooting singular tests.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tests passing.
