### PR TITLE
BCDA-9778: Adjust dockerfiles apk upgrade order

### DIFF
--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -41,12 +41,11 @@ RUN go build -ldflags "-X github.com/CMSgov/bcda-ssas-app/ssas/constants.Version
 FROM golang:1.25.4-alpine3.22
 
 RUN addgroup -S ssas-group && adduser -S ssas-user -G ssas-group && \
-    apk --no-cache add \
+    apk update upgrade --no-cache && \
+    apk add --no-cache \
         aws-cli \
         ca-certificates \
-        curl \
-        && \
-    apk update upgrade --no-cache
+        curl
 
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
 COPY --from=builder /go/src/github.com/CMSgov/bcda-ssas-app/ssas/cfg/configs ssas/cfg/configs

--- a/Dockerfiles/Dockerfile.ssas
+++ b/Dockerfiles/Dockerfile.ssas
@@ -41,10 +41,12 @@ RUN go build -ldflags "-X github.com/CMSgov/bcda-ssas-app/ssas/constants.Version
 FROM golang:1.25.4-alpine3.22
 
 RUN addgroup -S ssas-group && adduser -S ssas-user -G ssas-group && \
-    apk update upgrade --no-cache  && apk --no-cache add \
+    apk --no-cache add \
         aws-cli \
         ca-certificates \
-        curl
+        curl \
+        && \
+    apk update upgrade --no-cache
 
 WORKDIR /go/src/github.com/CMSgov/bcda-ssas-app
 COPY --from=builder /go/src/github.com/CMSgov/bcda-ssas-app/ssas/cfg/configs ssas/cfg/configs

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,9 +1,11 @@
 FROM golang:1.25.4-alpine3.22
 
-RUN apk update upgrade && apk add \
+RUN apk add \
     bash \
     build-base \
-    curl
+    curl \
+    && \
+    apk update upgrade
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
 

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,11 +1,10 @@
 FROM golang:1.25.4-alpine3.22
 
-RUN apk --no-cache add \
-    bash \
-    build-base \
-    curl \
-    && \
-    apk update upgrade --no-cache
+RUN apk update upgrade --no-cache && \
+    apk add --no-cache \
+        bash \
+        build-base \
+        curl
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
 

--- a/Dockerfiles/Dockerfile.tests
+++ b/Dockerfiles/Dockerfile.tests
@@ -1,11 +1,11 @@
 FROM golang:1.25.4-alpine3.22
 
-RUN apk add \
+RUN apk --no-cache add \
     bash \
     build-base \
     curl \
     && \
-    apk update upgrade
+    apk update upgrade --no-cache
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0
 


### PR DESCRIPTION
## 🎫 Ticket

Make apk upgrade come after adding other deps.

## 🛠 Changes

Make apk upgrade come after adding other deps.

## ℹ️ Context

Better security (make sure all deps are up to latest). Should also cover for newly found critical and high vulnerabilities.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local docker image build/testing.
