### PR TITLE
BCDA-9862: update waf-sync runners to arm64

### DIFF
--- a/.github/workflows/waf-sync-lambda-deploy.yml
+++ b/.github/workflows/waf-sync-lambda-deploy.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-bcda-ssas-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
     defaults:
       run:
         working-directory: ./lambda/wafsync
@@ -47,8 +47,10 @@ jobs:
       - name: Build WAF Sync Lambda zip file
         env:
           CGO_ENABLED: 0
+        # Build for amd64 on arm64 runner since lambda infra has not been updated
+        # todo: Change while/after working on BCDA-9939
         run: |
-          go build -o bootstrap main.go db.go aws.go mock_wafv2.go
+          env GOOS=linux GOARCH=amd64 go build -o bootstrap main.go db.go aws.go mock_wafv2.go
           zip function.zip bootstrap
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/waf-sync-lambda-integration-test.yml
+++ b/.github/workflows/waf-sync-lambda-integration-test.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-bcda-ssas-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
     defaults:
       run:
         working-directory: ./lambda/wafsync


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9862
[related bcda-app PR](https://github.com/CMSgov/bcda-app/pull/1340)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

Updated the following workflow runners to arm64:
- waf-sync lambda

Some workflows were not updated since they could not be tested at this time:
- deploy-all
- ci-checks

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  
Github runners are being updated to default to arm64 and this PR aims to migrate as many of them as possible now and test the results. 
Lambda changes were tested with the integration test workflow. Lambdas are still being built for amd64 until their supporting terraform is updated to accommodate the runtime change, and comments were added to indicate that. 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
