### PR TITLE
BCDA-9895: stress testing updates

### DIFF
--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -64,13 +64,25 @@ func main() {
 		log.Fatalf("Unknown endpoint: %s. Use 'token' or 'introspect'", endpoint)
 	}
 
-	results := runPerformanceTest(targeter)
+	results, metrics := runPerformanceTest(targeter)
 	var buf bytes.Buffer
 	_, err := results.WriteTo(&buf)
 	if err != nil {
 		panic(err)
 	}
-	writeResults(fmt.Sprintf("%s_api_plot", endpoint), buf)
+
+	timestamp := time.Now().Format("20060102150405")
+
+	// Write HTML results
+	writeResults(fmt.Sprintf("%s_api_plot_%s.html", endpoint, timestamp), buf.Bytes())
+
+	// Write JSON results
+	reporter := vegeta.NewJSONReporter(metrics)
+	var jsonBuf bytes.Buffer
+	if err := reporter(&jsonBuf); err != nil {
+		panic(err)
+	}
+	writeResults(fmt.Sprintf("%s_api_plot_%s.json", endpoint, timestamp), jsonBuf.Bytes())
 }
 
 func makeTokenTarget() vegeta.Targeter {
@@ -122,7 +134,7 @@ func makeIntrospectTarget(accessToken string) vegeta.Targeter {
 	})
 }
 
-func runPerformanceTest(target vegeta.Targeter) *plot.Plot {
+func runPerformanceTest(target vegeta.Targeter) (*plot.Plot, *vegeta.Metrics) {
 	fmt.Printf("running performance test for: %s\n", endpoint)
 	title := plot.Title(fmt.Sprintf("Performance Test - %s", endpoint))
 	p := plot.New(title)
@@ -140,7 +152,7 @@ func runPerformanceTest(target vegeta.Targeter) *plot.Plot {
 	}()
 	plotAttack(p, &metrics, target, rate, d)
 
-	return p
+	return p, &metrics
 }
 
 func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
@@ -153,12 +165,11 @@ func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rat
 	}
 }
 
-func writeResults(filename string, buf bytes.Buffer) {
+func writeResults(filename string, data []byte) {
 	re := regexp.MustCompile(`[^a-zA-Z0-9\.\-]`)
 	clean := re.ReplaceAllString(filename, "-")
-	data := buf.Bytes()
 	if len(data) > 0 {
-		fn := fmt.Sprintf("%s/%s.html", reportFilePath, clean)
+		fn := fmt.Sprintf("%s/%s", reportFilePath, clean)
 		fmt.Printf("Writing results: %s\n", fn)
 		err := os.WriteFile(fn, data, 0600)
 		if err != nil {

--- a/test/performance_test/readme.md
+++ b/test/performance_test/readme.md
@@ -20,6 +20,7 @@ The directory hosts performance stress testing suite for `bcda-ssas-app` using t
 ## Usage Examples
 
 Make sure you are in `bcda-ssas-app/test/performance_test`. Then, you can run normal `go run` commands.
+Note: you can run `make credentials` from the root directory to generate a client ID and secret.
 
 ### Scenario 1: Hitting `/token`
 This stress-tests generating token grants via the `POST /token` payload aggressively:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9895

## 🛠 Changes

- Added instructions for making credentials
- The output files now append a timestamp in the (YYYYMMDDHHMMSS) format immediately after the endpoint name
- Generate and save a parallel .json file alongside the .html file
- `writeResults` function was adjusted to handle arbitrary byte slices and file extensions dynamically, rather than being hardcoded to HTML generation

## ℹ️ Context

Minor updates based on feedback from PR: https://github.com/CMSgov/bcda-ssas-app/pull/300

## 🧪 Validation

Ran a stress test locally and validated the output
