### PR TITLE
BCDA-9895: stress testing updates

### DIFF
--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
@@ -25,6 +27,7 @@ var (
 
 	freq     int
 	duration int
+	insecure bool
 )
 
 func init() {
@@ -36,6 +39,7 @@ func init() {
 	flag.StringVar(&proto, "proto", "http", "protocol to use")
 	flag.StringVar(&reportFilePath, "report_path", "../../test_results/performance", "path to write the result.html")
 	flag.StringVar(&endpoint, "endpoint", "token", "endpoint to test ('token' or 'introspect')")
+	flag.BoolVar(&insecure, "insecure", false, "ignore certificates")
 	flag.Parse()
 
 	// create folder if doesn't exist for storing the results
@@ -50,6 +54,14 @@ func init() {
 func main() {
 	if clientID == "" || clientSecret == "" {
 		log.Fatal("clientID and clientSecret must be provided")
+	}
+
+	if strings.HasPrefix(apiHost, "http://") {
+		proto = "http"
+		apiHost = strings.TrimPrefix(apiHost, "http://")
+	} else if strings.HasPrefix(apiHost, "https://") {
+		proto = "https"
+		apiHost = strings.TrimPrefix(apiHost, "https://")
 	}
 
 	var targeter vegeta.Targeter
@@ -156,7 +168,9 @@ func runPerformanceTest(target vegeta.Targeter) (*plot.Plot, *vegeta.Metrics) {
 }
 
 func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
-	attacker := vegeta.NewAttacker()
+	attacker := vegeta.NewAttacker(
+		vegeta.TLSConfig(&tls.Config{InsecureSkipVerify: insecure}), //nolint:gosec
+	)
 	for results := range attacker.Attack(t, r, du, fmt.Sprintf("%dps:", r.Freq)) {
 		if err := p.Add(results); err != nil {
 			panic(err)
@@ -188,7 +202,11 @@ func getAccessToken(cID, cSecret string) string {
 	req.Header.Add("Accept", "application/json")
 
 	fmt.Printf("Fetching test access token for introspect test...\n")
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}, //nolint:gosec
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req) //nolint:gosec
 	if err != nil {
 		panic(fmt.Sprintf("failed to get token: %s", err.Error()))
 	}

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -64,13 +64,25 @@ func main() {
 		log.Fatalf("Unknown endpoint: %s. Use 'token' or 'introspect'", endpoint)
 	}
 
-	results := runPerformanceTest(targeter)
+	results, metrics := runPerformanceTest(targeter)
 	var buf bytes.Buffer
 	_, err := results.WriteTo(&buf)
 	if err != nil {
 		panic(err)
 	}
-	writeResults(fmt.Sprintf("%s_api_plot", endpoint), buf)
+
+	timestamp := time.Now().Format("20060102150405")
+
+	// Write HTML results
+	writeResults(fmt.Sprintf("%s_api_plot_%s.html", endpoint, timestamp), buf.Bytes())
+
+	// Write JSON results
+	reporter := vegeta.NewJSONReporter(metrics)
+	var jsonBuf bytes.Buffer
+	if err := reporter(&jsonBuf); err != nil {
+		panic(err)
+	}
+	writeResults(fmt.Sprintf("%s_api_plot_%s.json", endpoint, timestamp), jsonBuf.Bytes())
 }
 
 func makeTokenTarget() vegeta.Targeter {
@@ -122,7 +134,7 @@ func makeIntrospectTarget(accessToken string) vegeta.Targeter {
 	})
 }
 
-func runPerformanceTest(target vegeta.Targeter) *plot.Plot {
+func runPerformanceTest(target vegeta.Targeter) (*plot.Plot, *vegeta.Metrics) {
 	fmt.Printf("running performance test for: %s\n", endpoint)
 	title := plot.Title(fmt.Sprintf("Performance Test - %s", endpoint))
 	p := plot.New(title)
@@ -140,7 +152,7 @@ func runPerformanceTest(target vegeta.Targeter) *plot.Plot {
 	}()
 	plotAttack(p, &metrics, target, rate, d)
 
-	return p
+	return p, &metrics
 }
 
 func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
@@ -153,12 +165,11 @@ func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rat
 	}
 }
 
-func writeResults(filename string, buf bytes.Buffer) {
+func writeResults(filename string, data []byte) {
 	re := regexp.MustCompile(`[^a-zA-Z0-9\.\-]`)
 	clean := re.ReplaceAllString(filename, "-")
-	data := buf.Bytes()
 	if len(data) > 0 {
-		fn := fmt.Sprintf("%s/%s.html", reportFilePath, clean)
+		fn := fmt.Sprintf("%s/%s", reportFilePath, clean)
 		fmt.Printf("Writing results: %s\n", fn)
 		err := os.WriteFile(fn, data, 0600)
 		if err != nil {

--- a/test/performance_test/performance.go
+++ b/test/performance_test/performance.go
@@ -169,7 +169,7 @@ func runPerformanceTest(target vegeta.Targeter) (*plot.Plot, *vegeta.Metrics) {
 
 func plotAttack(p *plot.Plot, m *vegeta.Metrics, t vegeta.Targeter, r vegeta.Rate, du time.Duration) {
 	attacker := vegeta.NewAttacker(
-		vegeta.TLSConfig(&tls.Config{InsecureSkipVerify: insecure}), //nolint:gosec
+		vegeta.TLSConfig(&tls.Config{InsecureSkipVerify: insecure}), // #nosec G402
 	)
 	for results := range attacker.Attack(t, r, du, fmt.Sprintf("%dps:", r.Freq)) {
 		if err := p.Add(results); err != nil {
@@ -203,10 +203,10 @@ func getAccessToken(cID, cSecret string) string {
 
 	fmt.Printf("Fetching test access token for introspect test...\n")
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}, //nolint:gosec
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}, // #nosec G402
 	}
 	client := &http.Client{Transport: tr}
-	resp, err := client.Do(req) //nolint:gosec
+	resp, err := client.Do(req) // #nosec G704
 	if err != nil {
 		panic(fmt.Sprintf("failed to get token: %s", err.Error()))
 	}

--- a/test/performance_test/readme.md
+++ b/test/performance_test/readme.md
@@ -20,6 +20,7 @@ The directory hosts performance stress testing suite for `bcda-ssas-app` using t
 ## Usage Examples
 
 Make sure you are in `bcda-ssas-app/test/performance_test`. Then, you can run normal `go run` commands.
+Note: you can run `make credentials` from the root directory to generate a client ID and secret.
 
 ### Scenario 1: Hitting `/token`
 This stress-tests generating token grants via the `POST /token` payload aggressively:

--- a/test/performance_test/readme.md
+++ b/test/performance_test/readme.md
@@ -8,6 +8,7 @@ The directory hosts performance stress testing suite for `bcda-ssas-app` using t
 - `--freq`: Requests per second (default 10).
 - `--duration`: Total test duration in seconds (default 60).
 - `--endpoint`: Which endpoint to strike (`token` or `introspect`).
+- `--insecure`: Bypasses TLS certificate validation. **Critical for non-prod environments (like dev)** where certificates may be self-signed or non-compliant.
 
 **Execution Logic**:
 1. **If testing `/token`**:
@@ -21,6 +22,7 @@ The directory hosts performance stress testing suite for `bcda-ssas-app` using t
 
 Make sure you are in `bcda-ssas-app/test/performance_test`. Then, you can run normal `go run` commands.
 Note: you can run `make credentials` from the root directory to generate a client ID and secret.
+**Important**: When testing against non-prod environments (like dev) over HTTPS, ensure you include the `-insecure` flag to bypass TLS certificate validation errors.
 
 ### Scenario 1: Hitting `/token`
 This stress-tests generating token grants via the `POST /token` payload aggressively:
@@ -40,12 +42,13 @@ This fetches one single access token from `/token`, encodes it in JSON, and aggr
 
 ```bash
 go run performance.go \
-    -host="localhost:3104" \
+    -host="non-prod-instance-to-test.elb.amazonaws.com" \
     -clientID="<YOUR_DEV_CLIENT_ID>" \
     -clientSecret="<YOUR_DEV_CLIENT_SECRET>" \
     -endpoint="introspect" \
     -duration=60 \
-    -freq=15
+    -freq=15 \
+    -insecure
 ```
 
 After either suite runs, a performance test artifact (`[endpoint]_api_plot.html`) will automatically appear in `bcda-ssas-app/test_results/performance/`.


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9895

## 🛠 Changes

- Respect the protocol passed in the URL (http vs https)
- If the cert chain is self signed, support `-insecure`
- Updated usage examples

## 🧪 Validation

Tested by hitting the internal LB DNS
