### PR TITLE
BCDA-9940: Shift runners to prod/non-prod versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
   build_and_publish:
     needs: [ci_checks]
-    runs-on: codebuild-bcda-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   go_mod_tidy:
     name: Modules Lint
-    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
   lint_and_test:
     name: Lint and Test
-    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   go_mod_tidy:
     name: Modules Lint
-    runs-on: codebuild-bcda-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -39,7 +39,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-bcda-app-${{ contains(fromJSON('["prod", "sandbox"]'), inputs.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}} # This is called from bcda-app deploy-all workflow
+    runs-on: codebuild-bcda-ssas-app-${{ contains(fromJSON('["prod", "sandbox"]'), inputs.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}} # This is called from bcda-app deploy-all workflow
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@v4

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -39,7 +39,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-bcda-app-arm64-${{github.run_id}}-${{github.run_attempt}} # This is called from bcda-app deploy-all workflow
+    runs-on: codebuild-bcda-app-${{ contains(fromJSON('["prod", "sandbox"]'), inputs.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}} # This is called from bcda-app deploy-all workflow
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@v4

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   tag_and_release:
     name: Tag and Release
-    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Get AWS params
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/waf-sync-lambda-deploy.yml
+++ b/.github/workflows/waf-sync-lambda-deploy.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-${{ contains(fromJSON('["prod", "sandbox"]'), inputs.deploy_env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     defaults:
       run:
         working-directory: ./lambda/wafsync

--- a/.github/workflows/waf-sync-lambda-integration-test.yml
+++ b/.github/workflows/waf-sync-lambda-integration-test.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-bcda-ssas-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     defaults:
       run:
         working-directory: ./lambda/wafsync

--- a/docker/Dockerfile.ssas
+++ b/docker/Dockerfile.ssas
@@ -1,7 +1,8 @@
 ### OpenAPI docs
 FROM arm64v8/golang:1.26.0-alpine3.23 AS documentation
 
-RUN apk update upgrade --no-cache  && apk add \
+RUN RUN apk update && apk upgrade \
+    apk add --no-cache \
     binutils-gold \
     build-base \
     gcc \

--- a/docker/Dockerfile.ssas
+++ b/docker/Dockerfile.ssas
@@ -1,7 +1,7 @@
 ### OpenAPI docs
 FROM arm64v8/golang:1.26.0-alpine3.23 AS documentation
 
-RUN RUN apk update && apk upgrade \
+RUN apk update && apk upgrade \
     apk add --no-cache \
     binutils-gold \
     build-base \

--- a/docker/Dockerfile.ssas
+++ b/docker/Dockerfile.ssas
@@ -1,8 +1,7 @@
 ### OpenAPI docs
 FROM arm64v8/golang:1.26.0-alpine3.23 AS documentation
 
-RUN apk update && apk upgrade \
-    apk add --no-cache \
+RUN apk add --no-cache \
     binutils-gold \
     build-base \
     gcc \


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9940

## 🛠 Changes

- updating workflows to use the `runs-on:<prod|non-prod>` naming convention 
- workflows that do not specify an env use the default non-prod workflow; keeping them labelled as such and not updating the assumed role, since additional permissions or uses are not needed

## ℹ️ Context

Part of the effort to migrate workflows to arm64.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Workflows tested except:
- tag and release
- build and publish
- ci-checks

The last two run as part of the bcda-app workflow, so we will need to merge to test. Tag and release can be verified, but we will need to manually remove the tag/release.