### PR TITLE
BCDA-9940: Update build & publish runner

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
   build_and_publish:
     needs: [ci_checks]
-    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
   build_and_publish:
     needs: [ci_checks]
-    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -59,7 +59,7 @@ jobs:
   sonar-quality-gate:
     name: Sonarqube Quality Gate
     needs: lint_and_test
-    runs-on: codebuild-bcda-ssas-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-ssas-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set env vars from AWS params
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -82,6 +82,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
+            -Dsonar.scanner.arch=aarch64
             -Dsonar.projectKey=bcda-ssas-api
             -Dsonar.sources=.
             -Dsonar.working.directory=./sonar_workspace


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9940

## 🛠 Changes

- Updated build and publish to use bcda-app runner, since that is where is called from.
- Updated sonarqube runs on to use ssas runner

## ℹ️ Context

This workflow is failing because the ssas build and publish workflow is not being picked up by a runner. There is another workflow (ci checks) that needs to have the runner set to bcda-app, since that is where it's called from.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Must be merged to validate.
