### PR TITLE
BCDA-9940: update migrate workflow to use bcda-app runner

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -39,7 +39,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-bcda-ssas-app-${{ contains(fromJSON('["prod", "sandbox"]'), inputs.env) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}} # This is called from bcda-app deploy-all workflow
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -31,6 +31,8 @@ on:
 env:
   ENV: ${{ inputs.env || 'dev' }}
 
+
+
 permissions:
   id-token: write
   contents: read
@@ -39,7 +41,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-${{ github.event_name == 'workflow_dispatch' && 'bcda-app' || 'bcda-ssas-app' }}-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -41,7 +41,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-${{ github.event_name == 'workflow_dispatch' && 'bcda-app' || 'bcda-ssas-app' }}-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-${{ github.event_name == 'workflow_call' && 'bcda-app' || 'bcda-ssas-app' }}-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -31,8 +31,6 @@ on:
 env:
   ENV: ${{ inputs.env || 'dev' }}
 
-
-
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9940

## 🛠 Changes

- migrate workflow using conditional to determine which runner to use

## ℹ️ Context

Workflows that get called from another repo will not be picked up by runners from the current repo. Ex: If a BCDA-app workflow calls a ssas workflow where a ssas runner is specified, the parent workflow will fail, since it expects bcda-app runners. Adding a conditional will allow the workflow to run when it's called either from a different repo's workflow, or if it's run manually.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Currently testing.
