### PR TITLE
BCDA-9940: update migrate workflow runner name to api

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -39,7 +39,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-${{ github.event_name == 'workflow_call' && 'bcda-app' || 'bcda-ssas-app' }}-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9940

## 🛠 Changes

Runner name renamed to bcda-non-prod, since that is where it's called from.

## ℹ️ Context

Runners fail to pick up jobs if the repo != runner. Ex: Workflows called from BCDA API must use the BCDA API runner, or it fails to pick up the job. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Cannot verify until merged, but works for other workflows called from BCDA.
