### PR TITLE
BCDA-9940: migration workflow fix

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
         with:
+          repository: CMSgov/bcda-ssas-app
           ref: ${{ inputs.ref }}
       - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -69,7 +70,7 @@ jobs:
         run: |
           HOST=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier bcda-${{ env.ENV }}-aurora 2>&1 | jq -r '.DBClusterEndpoints[0].Endpoint' 2>&1)
           CONNECTION_URL=$(echo $DB_URL 2>&1 | sed -E "s/@.*\/bcda/\@$HOST\/bcda/" 2>&1)
-          migrate -database ${CONNECTION_URL}?x-migrations-table=schema_migrations_ssas -path db/migrations up
+          migrate -database ${CONNECTION_URL}?x-migrations-table=schema_migrations_ssas -path ./db/migrations up
       - name: Success Alert
         if: ${{ success() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -39,7 +39,7 @@ jobs:
   migrate_db:
     environment: ${{ inputs.env || 'dev' }}
     name: Migrate DB
-    runs-on: codebuild-${{ github.event_name == 'workflow_call' && 'bcda-app' || 'bcda-ssas-app' }}-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout BCDA SSAS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9940

## 🛠 Changes

- added repository to checkout step

## ℹ️ Context

Migrations for SSAS are failing to run when BCDA App workflow runners call it. The BCDA App is checked out by default when missing the repository line under the checkout action.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Unable to test this workflow change under the deploy all workflow; copied and pasted the ssas migration workflow under bcda-app runners to validate it worked: https://github.com/CMSgov/bcda-app/actions/runs/24735104472/job/72359713635
