### PR TITLE
BCDA-9944 switch to arm64 sonarqube runners

### DIFF
--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -78,11 +78,15 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
-            -Dsonar.scanner.arch=arm64
+            -Dsonar.scanner.arch=aarch64
             -Dsonar.projectKey=bcda-ssas-api
             -Dsonar.sources=.
             -Dsonar.working.directory=./sonar_workspace

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -82,7 +82,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
-            -Dsonar.scanner.arch=aarch64
+            -Dsonar.scanner.arch=arm64
             -Dsonar.projectKey=bcda-ssas-api
             -Dsonar.sources=.
             -Dsonar.working.directory=./sonar_workspace

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -89,7 +89,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@v7.1.0
         with:
           args:
-            -Dsonar.scanner.arch=arm64
+            -Dsonar.scanner.arch=aarch64
             -Dsonar.projectKey=bcda-ssas-api
             -Dsonar.sources=.
             -Dsonar.working.directory=./sonar_workspace

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -85,6 +85,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
+            -Dsonar.scanner.arch=arm64
             -Dsonar.projectKey=bcda-ssas-api
             -Dsonar.sources=.
             -Dsonar.working.directory=./sonar_workspace

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           name: code-coverage-report-ssas
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v7.1.0
         with:
           args:
             -Dsonar.scanner.arch=arm64

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: 24
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@v7.1.0
+        uses: sonarsource/sonarqube-scan-action@299e4b7
         with:
           args:
             -Dsonar.scanner.arch=aarch64

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -81,6 +81,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@v7.1.0
         with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -38,7 +38,7 @@ jobs:
 
   lint_and_test:
     name: Lint and Test
-    runs-on: codebuild-bcda-app-arm64-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
@@ -62,7 +62,7 @@ jobs:
   sonar-quality-gate:
     name: Sonarqube Quality Gate
     needs: lint_and_test
-    runs-on: codebuild-bcda-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-bcda-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: Set env vars from AWS params
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: 24
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@299e4b7
+        uses: sonarsource/sonarqube-scan-action@master
         with:
           args:
             -Dsonar.scanner.arch=aarch64


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9944

## 🛠 Changes

set sonarqube architecture to arm64


## ℹ️ Context

To conform with arm64 adoption

## 🧪 Validation

See ci-checks below
