### PR TITLE
BCDA-10120: Remove repo ref from workflow

### DIFF
--- a/.github/workflows/waf-sync-lambda-deploy.yml
+++ b/.github/workflows/waf-sync-lambda-deploy.yml
@@ -73,8 +73,6 @@ jobs:
         working-directory: ./lambda/wafsync
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-        with:
-            ref: carl-10120-add-datadog
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10120

## 🛠 Changes

Remove testing repo ref from workflow (it was used for testing).

## ℹ️ Context

Forgot to remove a testing repo ref from a workflow.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Successful workflow.
