### PR TITLE
BCDA-10049: update workflow actions to Node24

### DIFF
--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -20,7 +20,7 @@ jobs:
           repository: CMSgov/bcda-ssas-app
           ref: ${{ inputs.ref }}
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Tidy modules
@@ -43,7 +43,7 @@ jobs:
           repository: CMSgov/bcda-ssas-app 
           ref: ${{ inputs.ref }}
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build the stack

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -23,7 +23,7 @@ jobs:
           repository: CMSgov/bcda-ssas-app
           ref: ${{ inputs.ref }}
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Tidy modules
@@ -46,7 +46,7 @@ jobs:
           repository: CMSgov/bcda-ssas-app 
           ref: ${{ inputs.ref }}
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Build the stack

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -58,7 +58,7 @@ jobs:
           params: |
             DB_URL=/bcda/${{ env.ENV }}/sensitive/api/DATABASE_URL
       - name: Get Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Get golang-migrate

--- a/.github/workflows/waf-sync-lambda-deploy.yml
+++ b/.github/workflows/waf-sync-lambda-deploy.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: ./lambda/wafsync
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install Datadog Orchestrion APM


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10049

See related [bcda-app PR](https://github.com/CMSgov/bcda-app/pull/1409)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

upgraded the versions of the following workflow actions to newer versions that do not use Node20:
- setup-go


## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Actions were upgraded to address warnings we're seeing in our workflow logs
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ACTION_NAME. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
```

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

View the workflows run as part of this PR and ensure that there are no Node-related error messages present.