### PR TITLE
Address node warnings in workflows

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get Workflow Inputs
         run: echo "${{ toJSON(inputs) }}"
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/bcda-dev-github-actions
@@ -75,7 +75,7 @@ jobs:
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin '${{ env.ECR_NON_PROD_URL }}'
           docker image push ${{ env.ECR_NON_PROD_URL }}:${{ steps.version.outputs.version }}
       - name: Log into prod in order to push to prod ECR (only release images!)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         if: ${{ startsWith(steps.version.outputs.version, 'r') }}
         with:
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -78,6 +78,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         with:

--- a/.github/workflows/ci-checks-pr.yml
+++ b/.github/workflows/ci-checks-pr.yml
@@ -78,10 +78,6 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -81,6 +81,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -81,10 +81,6 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-ssas
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

- updated node-setup action versions
- update configure-aws-creds action versions

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without the team security engineer's approval:
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Some workflows are still using actions that use Node 20, which results in warning messages.
examples (initiated workflows in bcda-app call the offending workflows in ssas)
- https://github.com/CMSgov/bcda-ssas-app/actions/runs/31535073862
- https://github.com/CMSgov/bcda-app/actions/runs/31686421921
- http://github.com/CMSgov/bcda-app/actions/runs/31707602993

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->


ci-checks workflow in PR has no Node warnings